### PR TITLE
ignore changes when disk is autoresized

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,10 @@ resource "google_sql_database_instance" "default" {
   }
 
   replica_configuration = ["${var.replica_configuration}"]
+
+  lifecycle {
+    ignore_changes = ["disk_size"]
+  }
 }
 
 resource "google_sql_database" "default" {


### PR DESCRIPTION
@danisla @danawillow can you please review?
Everytime the DB disk is resized, terraform sees the change. This will prevent it.