### PR TITLE
Postgres support for private_service_access

### DIFF
--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -21,6 +21,13 @@ locals {
     enabled  = "${var.ip_configuration}"
     disabled = "${map()}"
   }
+
+  peering_completed_enabled = "${var.peering_completed != "" ? true : false}"
+
+  user_labels_including_tf_dependency = {
+    enabled  = "${merge(map("tf_dependency", var.peering_completed), var.user_labels)}"
+    disabled = "${var.user_labels}"
+  }
 }
 
 resource "google_sql_database_instance" "default" {
@@ -46,9 +53,7 @@ resource "google_sql_database_instance" "default" {
     // Define a label to force a dependency to the creation of the network peering.
     // Substitute this with a module dependency once the module is migrated to
     // Terraform 0.12
-    user_labels = "${merge(
-      map("tf_dependency", var.peering_completed),
-      var.user_labels)}"
+    user_labels = "${local.user_labels_including_tf_dependency["${local.peering_completed_enabled ? "enabled" : "disabled"}"]}"
 
     location_preference {
       zone = "${var.region}-${var.zone}"

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -41,8 +41,14 @@ resource "google_sql_database_instance" "default" {
     disk_size       = "${var.disk_size}"
     disk_type       = "${var.disk_type}"
     pricing_plan    = "${var.pricing_plan}"
-    user_labels     = "${var.user_labels}"
     database_flags  = ["${var.database_flags}"]
+
+    // Define a label to force a dependency to the creation of the network peering.
+    // Substitute this with a module dependency once the module is migrated to
+    // Terraform 0.12
+    user_labels = "${merge(
+      map("tf_dependency", var.peering_completed),
+      var.user_labels)}"
 
     location_preference {
       zone = "${var.region}-${var.zone}"

--- a/modules/postgresql/outputs.tf
+++ b/modules/postgresql/outputs.tf
@@ -25,6 +25,11 @@ output "instance_address" {
   description = "The IPv4 addesses assigned for the master instance"
 }
 
+output private_address {
+  value       = "${google_sql_database_instance.default.private_ip_address}"
+  description = "The private IP address assigned for the master instance"
+}
+
 output "instance_first_ip_address" {
   value       = "${google_sql_database_instance.default.first_ip_address}"
   description = "The first IPv4 address of the addresses assigned."

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -42,6 +42,11 @@ variable "zone" {
   description = "The zone for the master instance, it should be something like: `a`, `c`."
 }
 
+variable "peering_completed" {
+  description = "Optional. This is used to ensure that resources are created in the proper order when using private IPs and service network peering."
+  default     = ""
+}
+
 variable "activation_policy" {
   description = "The activation policy for the master instance.Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`."
   default     = "ALWAYS"


### PR DESCRIPTION
I am trying to use the `postgresql` submodule with the `private_service_access` submodule that was created as part of #35 for MySQL (really appreciate that work!). There's nothing in `private_service_access` that's MySQL specific, but the `peering_completed` variable workaround to enforce dependency order was only added to `safer_mysql`.

I also added a [`private_address` output](https://www.terraform.io/docs/providers/google/r/sql_database_instance.html#private_ip_address) to `postgresql`, trying to mirror the preexisting `instance_address` output. The README for the project says this works with a 1.12.x version of the google provider, but `private_ip_address` wasn't introduced until version [version 2.1.0](https://github.com/terraform-providers/terraform-provider-google/blob/master/CHANGELOG.md#210-february-26-2019). Does the README cover submodules, too? What's your policy on requiring a newer version of the provider?

I tried to stick as closely as possible to naming and descriptions to what was already in the codebase. Let me know if you'd like anything changed. With these changes I was able to use private networking on our postgres instance, which is awesome. Thanks!