### PR TITLE
Use self link in service networking connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - the root module has been deprecated [#56]
 
+### Fixed
+
+- The network reference in the `private_service_access` module uses the   self link. [#61]
+
 ## [1.2.0] - 2019-07-30
 
 ## [1.1.2] - 2019-06-14
@@ -36,5 +40,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 [1.0.1]: https://github.com/terraform-google-modules/terraform-google-sql-db/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/terraform-google-modules/terraform-google-sql-db/releases/tag/1.0.0
 
+[#61]: https://github.com/terraform-google-modules/terraform-google-sql-db/pull/61
 [#56]: https://github.com/terraform-google-modules/terraform-google-sql-db/pull/56
 [#43]: https://github.com/terraform-google-modules/terraform-google-sql-db/pull/43

--- a/modules/private_service_access/main.tf
+++ b/modules/private_service_access/main.tf
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+data "google_compute_network" "main" {
+  name = "${var.vpc_network}"
+
+  project = "${var.project_id}"
+}
+
 // We define a VPC peering subnet that will be peered with the
 // Cloud SQL instance network. The Cloud SQL instance will
 // have a private IP within the provided range.
@@ -21,20 +27,20 @@
 resource "google_compute_global_address" "google-managed-services-range" {
   provider      = "google-beta"
   project       = "${var.project_id}"
-  name          = "google-managed-services-${var.vpc_network}"
+  name          = "google-managed-services-${data.google_compute_network.main.name}"
   purpose       = "VPC_PEERING"
   address       = "${var.address}"
   prefix_length = "${var.prefix_length}"
   ip_version    = "${var.ip_version}"
   labels        = "${var.labels}"
   address_type  = "INTERNAL"
-  network       = "${var.vpc_network}"
+  network       = "${data.google_compute_network.main.self_link}"
 }
 
 # Creates the peering with the producer network.
 resource "google_service_networking_connection" "private_service_access" {
   provider                = "google-beta"
-  network                 = "${google_compute_global_address.google-managed-services-range.network}"
+  network                 = "${data.google_compute_network.main.self_link}"
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = ["${google_compute_global_address.google-managed-services-range.name}"]
 }


### PR DESCRIPTION
This commit adds a network data source to the private_service_access
submodule and uses that data source to obtain the required network
attributes.

This change fixes the following issue:

> Error: Provider produced inconsistent final plan
>
> When expanding the plan for
> module.private-service-access.google_service_networking_connection.private_service_access
> to include new values learned so far during apply, provider "google-beta"
> produced an invalid new value for .network: was
> cty.StringVal("test-vpc-private-access"), but now
> cty.StringVal("https://www.googleapis.com/compute/v1/projects/test-project/global/networks/test-vpc-private-access").
>
> This is a bug in the provider, which should be reported in the provider's own
> issue tracker.

Related to https://github.com/terraform-providers/terraform-provider-google/issues/4501.