### PR TITLE
Updating google and google-beta providers

### DIFF
--- a/examples/mysql-ha/main.tf
+++ b/examples/mysql-ha/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.13"
+  version = "~> 3.5"
 }
 
 provider "null" {

--- a/examples/mysql-private/main.tf
+++ b/examples/mysql-private/main.tf
@@ -15,11 +15,11 @@
  */
 
 provider "google" {
-  version = "~> 2.13"
+  version = "~> 3.5"
 }
 
 provider "google-beta" {
-  version = "~> 2.13"
+  version = "~> 3.5"
 }
 
 provider "null" {

--- a/examples/mysql-public/main.tf
+++ b/examples/mysql-public/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.13"
+  version = "~> 3.5"
 }
 
 provider "null" {

--- a/examples/postgresql-ha/main.tf
+++ b/examples/postgresql-ha/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.13"
+  version = "~> 3.5"
 }
 
 provider "null" {

--- a/examples/postgresql-public/main.tf
+++ b/examples/postgresql-public/main.tf
@@ -15,11 +15,11 @@
  */
 
 provider "google" {
-  version = "~> 2.13"
+  version = "~> 3.5"
 }
 
 provider "google-beta" {
-  version = "~> 2.13"
+  version = "~> 3.5"
 }
 
 provider "null" {

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -128,7 +128,7 @@ variable "backup_configuration" {
   })
   default = {
     binary_log_enabled = null
-    enabled            = null
+    enabled            = false
     start_time         = null
   }
 }

--- a/modules/mysql/versions.tf
+++ b/modules/mysql/versions.tf
@@ -17,7 +17,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google = "~> 2.13"
+    google = "~> 3.5"
     null   = "~> 2.1"
     random = "~> 2.2"
   }

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -125,7 +125,7 @@ variable "backup_configuration" {
   })
   default = {
     binary_log_enabled = null
-    enabled            = null
+    enabled            = false
     start_time         = null
   }
 }

--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -17,7 +17,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google = "~> 2.13"
+    google = "~> 3.5"
     null   = "~> 2.1"
     random = "~> 2.2"
   }

--- a/modules/private_service_access/versions.tf
+++ b/modules/private_service_access/versions.tf
@@ -17,8 +17,8 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google      = "~> 2.13"
-    google-beta = "~> 2.13"
+    google      = "~> 3.5"
+    google-beta = "~> 3.5"
     null        = "~> 2.1"
   }
 }

--- a/modules/safer_mysql/variables.tf
+++ b/modules/safer_mysql/variables.tf
@@ -132,7 +132,7 @@ variable "backup_configuration" {
   })
   default = {
     binary_log_enabled = null
-    enabled            = null
+    enabled            = false
     start_time         = null
   }
 }


### PR DESCRIPTION
Updating google and google-beta provider constraints to `~> 3.5`