### PR TITLE
Hardcode disable option as it is not valid for postgres

### DIFF
--- a/examples/postgresql-ha/main.tf
+++ b/examples/postgresql-ha/main.tf
@@ -78,9 +78,8 @@ module "pg" {
   }
 
   backup_configuration = {
-    enabled            = true
-    binary_log_enabled = false
-    start_time         = "20:55"
+    enabled    = true
+    start_time = "20:55"
   }
 
   // Read replica configurations

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -37,7 +37,7 @@ resource "google_sql_database_instance" "default" {
     dynamic "backup_configuration" {
       for_each = [var.backup_configuration]
       content {
-        binary_log_enabled = lookup(backup_configuration.value, "binary_log_enabled", null)
+        binary_log_enabled = false
         enabled            = lookup(backup_configuration.value, "enabled", null)
         start_time         = lookup(backup_configuration.value, "start_time", null)
       }

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -119,17 +119,14 @@ variable "user_labels" {
 variable "backup_configuration" {
   description = "The backup_configuration settings subblock for the database setings"
   type = object({
-    binary_log_enabled = bool
-    enabled            = bool
-    start_time         = string
+    enabled    = bool
+    start_time = string
   })
   default = {
-    binary_log_enabled = null
-    enabled            = false
-    start_time         = null
+    enabled    = false
+    start_time = null
   }
 }
-
 
 variable "authorized_gae_applications" {
   description = "The authorized gae applications for the Cloud SQL instances"


### PR DESCRIPTION
This removes `backup_configuration.binary_log_enabled` as an option in the postgres module, as attempting to set it as true results in an error:

```
Error: Error, failed to create instance <instance-name>: googleapi: Error 400: Invalid request: Binary log can only be enabled for MySQL instances., invalid

  on .terraform/modules/terraform-google-sql/modules/postgresql/main.tf line 26, in resource "google_sql_database_instance" "default":
  26: resource "google_sql_database_instance" "default" {
```