### PR TITLE
complete provision instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,28 @@ You can pass the service account credentials into this module by setting the fol
 
 See more [details](https://www.terraform.io/docs/providers/google/provider_reference.html#configuration-reference).
 
+## Provision Instructions
+
+This module has no root configuration. A module with no root configuration cannot be used directly.
+
+Copy and paste into your Terraform configuration, insert the variables, and run terraform init :
+
+```
+module "sql-db" {
+  source  = "GoogleCloudPlatform/sql-db/google//mysql"
+  version = "3.1.0"
+}
+```
+
+or :
+
+```
+module "sql-db" {
+  source  = "GoogleCloudPlatform/sql-db/google//postgres"
+  version = "3.1.0"
+}
+```
+
 ## Contributing
 
 Refer to the [contribution guidelines](./CONTRIBUTING.md) for


### PR DESCRIPTION
cause this is not enough to use this module from the public registry

```
module "sql-db" {
  source  = "GoogleCloudPlatform/sql-db/google"
  version = "3.1.0"
}
```

This warn help us, but can be more explicit :
This module version (3.1.0) has no root configuration. A module with no root configuration cannot be used directly.
Use the submodules dropdown above to view the 4 submodules defined within this module.

So add a small usage guideline in the readme and examples with remote usage can help us