### PR TITLE
Support new regional HA MySQL

### DIFF
--- a/examples/mysql-ha/main.tf
+++ b/examples/mysql-ha/main.tf
@@ -49,6 +49,7 @@ module "mysql" {
   // Master configurations
   tier                            = "db-n1-standard-1"
   zone                            = "c"
+  availability_type               = "REGIONAL"
   maintenance_window_day          = 7
   maintenance_window_hour         = 12
   maintenance_window_update_track = "stable"
@@ -122,57 +123,6 @@ module "mysql" {
   }
 
   read_replica_ip_configuration = {
-    ipv4_enabled    = true
-    require_ssl     = false
-    private_network = null
-    authorized_networks = [
-      {
-        name  = "${var.project_id}-cidr"
-        value = var.mysql_ha_external_ip_range
-      },
-    ]
-  }
-
-  // Failover replica configurations
-  failover_replica                                 = true
-  failover_replica_name_suffix                     = "-test"
-  failover_replica_tier                            = "db-n1-standard-1"
-  failover_replica_zone                            = "a"
-  failover_replica_activation_policy               = "ALWAYS"
-  failover_replica_crash_safe_replication          = true
-  failover_replica_disk_autoresize                 = true
-  failover_replica_disk_type                       = "PD_SSD"
-  failover_replica_replication_type                = "SYNCHRONOUS"
-  failover_replica_maintenance_window_day          = 3
-  failover_replica_maintenance_window_hour         = 20
-  failover_replica_maintenance_window_update_track = "canary"
-
-  failover_replica_user_labels = {
-    baz = "boo"
-  }
-
-  failover_replica_database_flags = [
-    {
-      name  = "long_query_time"
-      value = "1"
-    },
-  ]
-
-  failover_replica_configuration = {
-    dump_file_path            = "gs://${var.project_id}.appspot.com/tmp"
-    connect_retry_interval    = 5
-    ca_certificate            = null
-    client_certificate        = null
-    client_key                = null
-    failover_target           = null
-    master_heartbeat_period   = null
-    password                  = null
-    ssl_cipher                = null
-    username                  = null
-    verify_server_certificate = null
-  }
-
-  failover_replica_ip_configuration = {
     ipv4_enabled    = true
     require_ssl     = false
     private_network = null

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -9,6 +9,7 @@
 | additional\_databases | A list of databases to be created in your cluster | object | `<list>` | no |
 | additional\_users | A list of users to be created in your cluster | object | `<list>` | no |
 | authorized\_gae\_applications | The list of authorized App Engine project names | list(string) | `<list>` | no |
+| availability\_type | The availability type for the master instance. Can be either `ZONAL` or `REGIONAL`. | string | `"ZONAL"` | no |
 | backup\_configuration | The backup_configuration settings subblock for the database setings | object | `<map>` | no |
 | create\_timeout | The optional timout that is applied to limit long database creates. | string | `"10m"` | no |
 | database\_flags | List of Cloud SQL flags that are applied to the database server | object | `<list>` | no |

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -9,7 +9,7 @@
 | additional\_databases | A list of databases to be created in your cluster | object | `<list>` | no |
 | additional\_users | A list of users to be created in your cluster | object | `<list>` | no |
 | authorized\_gae\_applications | The list of authorized App Engine project names | list(string) | `<list>` | no |
-| availability\_type | The availability type for the master instance. Can be either `ZONAL` or `REGIONAL`. | string | `"ZONAL"` | no |
+| availability\_type | The availability type for the master instance. Can be either `REGIONAL` or `null`. | string | `"REGIONAL"` | no |
 | backup\_configuration | The backup_configuration settings subblock for the database setings | object | `<map>` | no |
 | create\_timeout | The optional timout that is applied to limit long database creates. | string | `"10m"` | no |
 | database\_flags | List of Cloud SQL flags that are applied to the database server | object | `<list>` | no |

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -56,9 +56,9 @@ variable "activation_policy" {
 }
 
 variable "availability_type" {
-  description = "The availability type for the master instance. Can be either `ZONAL` or `REGIONAL`."
+  description = "The availability type for the master instance. Can be either `REGIONAL` or `null`."
   type        = string
-  default     = "ZONAL"
+  default     = "REGIONAL"
 }
 
 variable "authorized_gae_applications" {

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -55,6 +55,12 @@ variable "activation_policy" {
   default     = "ALWAYS"
 }
 
+variable "availability_type" {
+  description = "The availability type for the master instance. Can be either `ZONAL` or `REGIONAL`."
+  type        = string
+  default     = "ZONAL"
+}
+
 variable "authorized_gae_applications" {
   description = "The list of authorized App Engine project names"
   type        = list(string)

--- a/test/integration/mysql-ha/controls/mysql.rb
+++ b/test/integration/mysql-ha/controls/mysql.rb
@@ -17,7 +17,7 @@ basename   = attribute('name')
 authorized_network = attribute('authorized_network')
 
 describe google_sql_database_instances(project: project_id).where(instance_name: /#{basename}/) do
-  its(:count) { should eq 5 }
+  its(:count) { should eq 4 }
 end
 
 describe google_sql_database_instance(project: project_id, database: basename) do

--- a/test/integration/mysql-ha/controls/mysql.rb
+++ b/test/integration/mysql-ha/controls/mysql.rb
@@ -24,6 +24,7 @@ describe google_sql_database_instance(project: project_id, database: basename) d
   let(:expected_settings) {
     {
       activation_policy: "ALWAYS",
+      availability_type: "REGIONAL",
       data_disk_size_gb: 10,
       data_disk_type: "PD_SSD",
       kind: "sql#settings",
@@ -55,41 +56,6 @@ describe google_sql_database_instance(project: project_id, database: basename) d
   it { expect(location_preference).to include(kind: "sql#locationPreference", zone: "us-central1-c") }
   it { expect(maintenance_window).to include(kind: "sql#maintenanceWindow", day: 7, hour: 12, update_track: "stable") }
   it { expect(user_labels).to include(foo: "bar") }
-end
-
-describe google_sql_database_instance(project: project_id, database: "#{basename}-failover-test") do
-  let(:expected_settings) {
-    {
-      activation_policy: "ALWAYS",
-      data_disk_size_gb: 10,
-      data_disk_type: "PD_SSD",
-      kind: "sql#settings",
-      pricing_plan: "PER_USE",
-      replication_type: "SYNCHRONOUS",
-      storage_auto_resize: true,
-      storage_auto_resize_limit: 0,
-      tier: "db-n1-standard-1",
-    }
-  }
-  let(:settings)                { subject.settings.item }
-  let(:ip_configuration)        { settings[:ip_configuration] }
-  let(:database_flags)          { settings[:database_flags] }
-  let(:location_preference)     { settings[:location_preference] }
-  let(:maintenance_window)      { settings[:maintenance_window] }
-  let(:user_labels)             { settings[:user_labels] }
-
-  its(:backend_type)     { should eq 'SECOND_GEN' }
-  its(:database_version) { should eq 'MYSQL_5_7' }
-  its(:state)            { should eq 'RUNNABLE' }
-  its(:region)           { should eq 'us-central1' }
-  its(:gce_zone)         { should eq 'us-central1-a' }
-
-  it { expect(settings).to include(expected_settings) }
-  it { expect(ip_configuration).to include(authorized_networks: [{kind: 'sql#aclEntry', name: "#{project_id}-cidr", value: authorized_network}], ipv4_enabled: true, require_ssl: false) }
-  it { expect(database_flags).to include(name: "long_query_time", value: "1") }
-  it { expect(location_preference).to include(kind: "sql#locationPreference", zone: "us-central1-a") }
-  it { expect(maintenance_window).to include(kind: "sql#maintenanceWindow", day: 3, hour: 20, update_track: "canary") }
-  it { expect(user_labels).to include(baz: "boo") }
 end
 
 %i[a b c].each_with_index do |zone, index|


### PR DESCRIPTION
Closes https://github.com/terraform-google-modules/terraform-google-sql-db/issues/71

https://cloud.google.com/sql/docs/mysql/high-availability#HA-configuration
>The HA configuration, sometimes called a cluster, provides data redundancy. A Cloud SQL instance configured for HA is also called a regional instance and is located in a primary and secondary zone within the configured region. Within a regional instance, the configuration is made up of a primary instance (master) and a standby instance. Through synchronous replication to each zone's persistent disk, all writes made to the primary instance are also made to the standby instance. In the event of an instance or zone failure, this configuration reduces downtime, and your data continues to be available to client applications.

>Note: The standby instance cannot be used for read queries. This differs from the Cloud SQL for MySQL legacy HA configuration.

WIP still need to test/update docs

I can also remove the legacy replica stuff for https://github.com/terraform-google-modules/terraform-google-sql-db/issues/97 but that does mean a breaking release/2 step migration path ([Updating an instance from legacy to current high availability](https://cloud.google.com/sql/docs/mysql/configure-ha#updating_an_instance_from_legacy_to_current)). Thoughts @morgante ?



