### PR TITLE
Move users/databases to for_each

### DIFF
--- a/examples/mysql-ha/main.tf
+++ b/examples/mysql-ha/main.tf
@@ -190,8 +190,6 @@ module "mysql" {
 
   additional_databases = [
     {
-      project   = var.project_id
-      instance  = local.instance_name
       name      = "${var.mysql_ha_name}-additional"
       charset   = "utf8mb4"
       collation = "utf8mb4_general_ci"
@@ -203,18 +201,14 @@ module "mysql" {
 
   additional_users = [
     {
-      project  = var.project_id
       name     = "tftest2"
       password = "abcdefg"
       host     = "localhost"
-      instance = local.instance_name
     },
     {
-      project  = var.project_id
       name     = "tftest3"
       password = "abcdefg"
       host     = "localhost"
-      instance = local.instance_name
     },
   ]
 }

--- a/examples/mysql-private/main.tf
+++ b/examples/mysql-private/main.tf
@@ -74,18 +74,14 @@ module "safer-mysql-db" {
   // Cloud SQL proxy.
   additional_users = [
     {
-      project  = var.project_id
       name     = "app"
       password = "PaSsWoRd"
       host     = "localhost"
-      instance = local.instance_name
     },
     {
-      project  = var.project_id
       name     = "readonly"
       password = "PaSsWoRd"
       host     = "localhost"
-      instance = local.instance_name
     },
   ]
 

--- a/examples/postgresql-ha/main.tf
+++ b/examples/postgresql-ha/main.tf
@@ -143,8 +143,6 @@ module "pg" {
       name      = "${var.pg_ha_name}-additional"
       charset   = "UTF8"
       collation = "en_US.UTF8"
-      instance  = local.instance_name
-      project   = var.project_id
     },
   ]
 
@@ -153,18 +151,14 @@ module "pg" {
 
   additional_users = [
     {
-      project  = var.project_id
       name     = "tftest2"
       password = "abcdefg"
       host     = "localhost"
-      instance = local.instance_name
     },
     {
-      project  = var.project_id
       name     = "tftest3"
       password = "abcdefg"
       host     = "localhost"
-      instance = local.instance_name
     },
   ]
 }

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -465,11 +465,9 @@ variable "db_collation" {
 variable "additional_databases" {
   description = "A list of databases to be created in your cluster"
   type = list(object({
-    project   = string
     name      = string
     charset   = string
     collation = string
-    instance  = string
   }))
   default = []
 }
@@ -495,11 +493,9 @@ variable "user_password" {
 variable "additional_users" {
   description = "A list of users to be created in your cluster"
   type = list(object({
-    project  = string
     name     = string
     password = string
     host     = string
-    instance = string
   }))
   default = []
 }

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -144,7 +144,6 @@ resource "google_sql_user" "additional_users" {
   project    = var.project_id
   name       = each.value.name
   password   = lookup(each.value, "password", random_id.user-password.hex)
-  host       = lookup(each.value, "host", var.user_host)
   instance   = google_sql_database_instance.default.name
   depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -21,6 +21,9 @@ locals {
     enabled  = var.ip_configuration
     disabled = {}
   }
+
+  databases = { for db in var.additional_databases : db.name => db }
+  users     = { for u in var.additional_users : u.name => u }
 }
 
 resource "google_sql_database_instance" "default" {
@@ -110,11 +113,11 @@ resource "google_sql_database" "default" {
 }
 
 resource "google_sql_database" "additional_databases" {
-  count      = length(var.additional_databases)
+  for_each   = local.databases
   project    = var.project_id
-  name       = var.additional_databases[count.index]["name"]
-  charset    = lookup(var.additional_databases[count.index], "charset", "")
-  collation  = lookup(var.additional_databases[count.index], "collation", "")
+  name       = each.value.name
+  charset    = lookup(each.value, "charset", null)
+  collation  = lookup(each.value, "collation", null)
   instance   = google_sql_database_instance.default.name
   depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }
@@ -137,14 +140,11 @@ resource "google_sql_user" "default" {
 }
 
 resource "google_sql_user" "additional_users" {
-  count   = length(var.additional_users)
-  project = var.project_id
-  name    = var.additional_users[count.index]["name"]
-  password = lookup(
-    var.additional_users[count.index],
-    "password",
-    random_id.user-password.hex,
-  )
+  for_each   = local.users
+  project    = var.project_id
+  name       = each.value.name
+  password   = lookup(each.value, "password", random_id.user-password.hex)
+  host       = lookup(each.value, "host", var.user_host)
   instance   = google_sql_database_instance.default.name
   depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -307,11 +307,9 @@ variable "db_collation" {
 variable "additional_databases" {
   description = "A list of databases to be created in your cluster"
   type = list(object({
-    project   = string
     name      = string
     charset   = string
     collation = string
-    instance  = string
   }))
   default = []
 }
@@ -331,11 +329,8 @@ variable "user_password" {
 variable "additional_users" {
   description = "A list of users to be created in your cluster"
   type = list(object({
-    project  = string
     name     = string
     password = string
-    host     = string
-    instance = string
   }))
   default = []
 }

--- a/modules/safer_mysql/variables.tf
+++ b/modules/safer_mysql/variables.tf
@@ -426,11 +426,9 @@ variable "db_collation" {
 variable "additional_databases" {
   description = "A list of databases to be created in your cluster"
   type = list(object({
-    project   = string
     name      = string
     charset   = string
     collation = string
-    instance  = string
   }))
   default = []
 }
@@ -450,11 +448,9 @@ variable "user_password" {
 variable "additional_users" {
   description = "A list of users to be created in your cluster"
   type = list(object({
-    project  = string
     name     = string
     password = string
     host     = string
-    instance = string
   }))
   default = []
 }


### PR DESCRIPTION
^
Closes #96

Noticed a couple of object fields `instance` and` project` were never used so also removed them

To consider
- Merge `users` and `additonal_users`  + same for databases, seems a bit pointless having them seperate and since we've already done a breaking API change might as well merge them now.
- Move read_replicas to `for_each`