### PR TITLE
add availability_type support for safer_mysql

### DIFF
--- a/modules/safer_mysql/README.md
+++ b/modules/safer_mysql/README.md
@@ -169,6 +169,7 @@ mysql -S $HOME/mysql_sockets/myproject:region:instance -u user -p
 | additional\_users | A list of users to be created in your cluster | object | `<list>` | no |
 | assign\_public\_ip | Set to true if the master instance should also have a public IP (less secure). | string | `"false"` | no |
 | authorized\_gae\_applications | The list of authorized App Engine project names | list(string) | `<list>` | no |
+| availability\_type | The availability type for the master instance. Can be either `REGIONAL` or `null`. | string | `"REGIONAL"` | no |
 | backup\_configuration | The backup_configuration settings subblock for the database setings | object | `<map>` | no |
 | create\_timeout | The optional timout that is applied to limit long database creates. | string | `"15m"` | no |
 | database\_flags | The database flags for the master instance. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | object | `<list>` | no |

--- a/modules/safer_mysql/main.tf
+++ b/modules/safer_mysql/main.tf
@@ -23,6 +23,7 @@ module "safer_mysql" {
   zone                            = var.zone
   tier                            = var.tier
   activation_policy               = var.activation_policy
+  availability_type               = var.availability_type
   authorized_gae_applications     = var.authorized_gae_applications
   disk_autoresize                 = var.disk_autoresize
   disk_size                       = var.disk_size

--- a/modules/safer_mysql/variables.tf
+++ b/modules/safer_mysql/variables.tf
@@ -60,6 +60,12 @@ variable "activation_policy" {
   default     = "ALWAYS"
 }
 
+variable "availability_type" {
+  description = "The availability type for the master instance. Can be either `REGIONAL` or `null`."
+  type        = string
+  default     = "REGIONAL"
+}
+
 variable "authorized_gae_applications" {
   description = "The list of authorized App Engine project names"
   type        = list(string)


### PR DESCRIPTION
I notice that the support for availability_type is recently merged for mysql, but not added for safer_mysql.