### PR TITLE
Added: random_id for mysql instance name

### DIFF
--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -32,6 +32,7 @@ The following dependency must be available for SQL Server module:
 | name | The name of the Cloud SQL resources | string | n/a | yes |
 | pricing\_plan | The pricing plan for the master instance. | string | `"PER_USE"` | no |
 | project\_id | The project ID to manage the Cloud SQL resources | string | n/a | yes |
+| random\_instance\_name | Sets random suffix at the end of the Cloud SQL resource name | bool | `"false"` | no |
 | region | The region of the Cloud SQL resources | string | `"us-central1"` | no |
 | root\_password | MSSERVER password for the root user. If not set, a random one will be generated and available in the root_password output variable. | string | `""` | no |
 | tier | The tier for the master instance. | string | `"db-custom-2-3840"` | no |

--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -40,7 +40,7 @@ resource "random_password" "root-password" {
 resource "google_sql_database_instance" "default" {
   provider         = google-beta
   project          = var.project_id
-  name             = var.random_instance_name ? "${var.name}-${random_id.suffix.hex}" : var.name
+  name             = var.random_instance_name ? "${var.name}-${random_id.suffix[0].hex}" : var.name
   database_version = var.database_version
   region           = var.region
   root_password    = coalesce(var.root_password, random_password.root-password.result)

--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -26,6 +26,12 @@ locals {
   users     = { for u in var.additional_users : u.name => u }
 }
 
+resource "random_id" "suffix" {
+  count = var.random_instance_name ? 1 : 0
+
+  byte_length = 4
+}
+
 resource "random_password" "root-password" {
   length  = 8
   special = true
@@ -34,7 +40,7 @@ resource "random_password" "root-password" {
 resource "google_sql_database_instance" "default" {
   provider         = google-beta
   project          = var.project_id
-  name             = var.name
+  name             = var.random_instance_name ? "${var.name}-${random_id.suffix.hex}" : var.name
   database_version = var.database_version
   region           = var.region
   root_password    = coalesce(var.root_password, random_password.root-password.result)

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -24,6 +24,12 @@ variable "name" {
   description = "The name of the Cloud SQL resources"
 }
 
+variable "random_instance_name" {
+  type        = bool
+  description = "Sets random suffix at the end of the Cloud SQL resource name"
+  default     = false
+}
+
 // required
 variable "database_version" {
   description = "The database version to use: SQLSERVER_2017_STANDARD, SQLSERVER_2017_ENTERPRISE, SQLSERVER_2017_EXPRESS, or SQLSERVER_2017_WEB"

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -48,7 +48,7 @@
 | name | The name of the Cloud SQL resources | string | n/a | yes |
 | pricing\_plan | The pricing plan for the master instance. | string | `"PER_USE"` | no |
 | project\_id | The project ID to manage the Cloud SQL resources | string | n/a | yes |
-| random\_instance\_name | To use a random prefix at the end of the Cloud SQL resource | bool | `"false"` | no |
+| random\_instance\_name | Sets rando prefix at the end of the Cloud SQL resource name | bool | `"false"` | no |
 | read\_replica\_activation\_policy | The activation policy for the read replica instances. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
 | read\_replica\_configuration | The replica configuration for use in all read replica instances. | object | `<map>` | no |
 | read\_replica\_crash\_safe\_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | bool | `"true"` | no |

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -48,6 +48,7 @@
 | name | The name of the Cloud SQL resources | string | n/a | yes |
 | pricing\_plan | The pricing plan for the master instance. | string | `"PER_USE"` | no |
 | project\_id | The project ID to manage the Cloud SQL resources | string | n/a | yes |
+| random\_instance\_name | To use a random prefix at the end of the Cloud SQL resource | bool | `"false"` | no |
 | read\_replica\_activation\_policy | The activation policy for the read replica instances. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
 | read\_replica\_configuration | The replica configuration for use in all read replica instances. | object | `<map>` | no |
 | read\_replica\_crash\_safe\_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | bool | `"true"` | no |

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -48,7 +48,7 @@
 | name | The name of the Cloud SQL resources | string | n/a | yes |
 | pricing\_plan | The pricing plan for the master instance. | string | `"PER_USE"` | no |
 | project\_id | The project ID to manage the Cloud SQL resources | string | n/a | yes |
-| random\_instance\_name | Sets rando prefix at the end of the Cloud SQL resource name | bool | `"false"` | no |
+| random\_instance\_name | Sets random prefix at the end of the Cloud SQL resource name | bool | `"false"` | no |
 | read\_replica\_activation\_policy | The activation policy for the read replica instances. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
 | read\_replica\_configuration | The replica configuration for use in all read replica instances. | object | `<map>` | no |
 | read\_replica\_crash\_safe\_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | bool | `"true"` | no |

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -48,7 +48,7 @@
 | name | The name of the Cloud SQL resources | string | n/a | yes |
 | pricing\_plan | The pricing plan for the master instance. | string | `"PER_USE"` | no |
 | project\_id | The project ID to manage the Cloud SQL resources | string | n/a | yes |
-| random\_instance\_name | Sets random prefix at the end of the Cloud SQL resource name | bool | `"false"` | no |
+| random\_instance\_name | Sets random suffix at the end of the Cloud SQL resource name | bool | `"false"` | no |
 | read\_replica\_activation\_policy | The activation policy for the read replica instances. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
 | read\_replica\_configuration | The replica configuration for use in all read replica instances. | object | `<map>` | no |
 | read\_replica\_crash\_safe\_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | bool | `"true"` | no |

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -38,7 +38,7 @@ resource "random_id" "prefix" {
 resource "google_sql_database_instance" "default" {
   provider            = google-beta
   project             = var.project_id
-  name                = "${var.name}-${random_id.prefix.hex}"
+  name                = var.random_instance_name ? "${var.name}-${random_id.prefix.hex}" : var.name
   database_version    = var.database_version
   region              = var.region
   encryption_key_name = var.encryption_key_name

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -31,14 +31,16 @@ locals {
   backups_enabled    = var.availability_type == "REGIONAL" ? true : lookup(var.backup_configuration, "enabled", null)
 }
 
-resource "random_id" "prefix" {
+resource "random_id" "suffix" {
+  count = var.random_instance_name ? 1 : 0
+
   byte_length = 4
 }
 
 resource "google_sql_database_instance" "default" {
   provider            = google-beta
   project             = var.project_id
-  name                = var.random_instance_name ? "${var.name}-${random_id.prefix.hex}" : var.name
+  name                = var.random_instance_name ? "${var.name}-${random_id.suffix.hex}" : var.name
   database_version    = var.database_version
   region              = var.region
   encryption_key_name = var.encryption_key_name

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -40,7 +40,7 @@ resource "random_id" "suffix" {
 resource "google_sql_database_instance" "default" {
   provider            = google-beta
   project             = var.project_id
-  name                = var.random_instance_name ? "${var.name}-${random_id.suffix.hex}" : var.name
+  name                = var.random_instance_name ? "${var.name}-${random_id.suffix[0].hex}" : var.name
   database_version    = var.database_version
   region              = var.region
   encryption_key_name = var.encryption_key_name

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -24,6 +24,12 @@ variable "name" {
   description = "The name of the Cloud SQL resources"
 }
 
+variable "random_instance_name" {
+  type        = bool
+  description = "To use a random prefix at the end of the Cloud SQL resource"
+  default     = false
+}
+
 // required
 variable "database_version" {
   description = "The database version to use"

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -26,7 +26,7 @@ variable "name" {
 
 variable "random_instance_name" {
   type        = bool
-  description = "To use a random prefix at the end of the Cloud SQL resource"
+  description = "Sets rando prefix at the end of the Cloud SQL resource name"
   default     = false
 }
 

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -26,7 +26,7 @@ variable "name" {
 
 variable "random_instance_name" {
   type        = bool
-  description = "Sets rando prefix at the end of the Cloud SQL resource name"
+  description = "Sets random prefix at the end of the Cloud SQL resource name"
   default     = false
 }
 

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -26,7 +26,7 @@ variable "name" {
 
 variable "random_instance_name" {
   type        = bool
-  description = "Sets random prefix at the end of the Cloud SQL resource name"
+  description = "Sets random suffix at the end of the Cloud SQL resource name"
   default     = false
 }
 

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -30,6 +30,7 @@
 | name | The name of the Cloud SQL resources | string | n/a | yes |
 | pricing\_plan | The pricing plan for the master instance. | string | `"PER_USE"` | no |
 | project\_id | The project ID to manage the Cloud SQL resources | string | n/a | yes |
+| random\_instance\_name | Sets random suffix at the end of the Cloud SQL resource name | bool | `"false"` | no |
 | read\_replica\_activation\_policy | The activation policy for the read replica instances.Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
 | read\_replica\_availability\_type | The availability type for the read replica instances.This is only used to set up high availability for the PostgreSQL instances. Can be either `ZONAL` or `REGIONAL`. | string | `"ZONAL"` | no |
 | read\_replica\_configuration | The replica configuration for use in all read replica instances. | object | `<map>` | no |

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -26,10 +26,16 @@ locals {
   users     = { for u in var.additional_users : u.name => u }
 }
 
+resource "random_id" "suffix" {
+  count = var.random_instance_name ? 1 : 0
+
+  byte_length = 4
+}
+
 resource "google_sql_database_instance" "default" {
   provider            = google-beta
   project             = var.project_id
-  name                = var.name
+  name                = var.random_instance_name ? "${var.name}-${random_id.suffix.hex}" : var.name
   database_version    = var.database_version
   region              = var.region
   encryption_key_name = var.encryption_key_name

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -35,7 +35,7 @@ resource "random_id" "suffix" {
 resource "google_sql_database_instance" "default" {
   provider            = google-beta
   project             = var.project_id
-  name                = var.random_instance_name ? "${var.name}-${random_id.suffix.hex}" : var.name
+  name                = var.random_instance_name ? "${var.name}-${random_id.suffix[0].hex}" : var.name
   database_version    = var.database_version
   region              = var.region
   encryption_key_name = var.encryption_key_name

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -24,6 +24,12 @@ variable "name" {
   description = "The name of the Cloud SQL resources"
 }
 
+variable "random_instance_name" {
+  type        = bool
+  description = "Sets random suffix at the end of the Cloud SQL resource name"
+  default     = false
+}
+
 // required
 variable "database_version" {
   description = "The database version to use"

--- a/modules/safer_mysql/README.md
+++ b/modules/safer_mysql/README.md
@@ -205,6 +205,7 @@ mysql -S $HOME/mysql_sockets/myproject:region:instance -u user -p
 | name | The name of the Cloud SQL resources | string | n/a | yes |
 | pricing\_plan | The pricing plan for the master instance. | string | `"PER_USE"` | no |
 | project\_id | The project ID to manage the Cloud SQL resources | string | n/a | yes |
+| random\_instance\_name | Sets random suffix at the end of the Cloud SQL resource name | bool | `"false"` | no |
 | read\_replica\_activation\_policy | The activation policy for the read replica instances. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
 | read\_replica\_configuration | The replica configuration for use in all read replica instances. | object | `<map>` | no |
 | read\_replica\_crash\_safe\_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | bool | `"true"` | no |

--- a/modules/safer_mysql/main.tf
+++ b/modules/safer_mysql/main.tf
@@ -13,11 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+resource "random_id" "suffix" {
+  count = var.random_instance_name ? 1 : 0
+
+  byte_length = 4
+}
 
 module "safer_mysql" {
   source                          = "../mysql"
   project_id                      = var.project_id
-  name                            = var.name
+  name                            = var.random_instance_name ? "${var.name}-${random_id.suffix.hex}" : var.name
   database_version                = var.database_version
   region                          = var.region
   zone                            = var.zone

--- a/modules/safer_mysql/main.tf
+++ b/modules/safer_mysql/main.tf
@@ -22,7 +22,7 @@ resource "random_id" "suffix" {
 module "safer_mysql" {
   source                          = "../mysql"
   project_id                      = var.project_id
-  name                            = var.random_instance_name ? "${var.name}-${random_id.suffix.hex}" : var.name
+  name                            = var.random_instance_name ? "${var.name}-${random_id.suffix[0].hex}" : var.name
   database_version                = var.database_version
   region                          = var.region
   zone                            = var.zone

--- a/modules/safer_mysql/variables.tf
+++ b/modules/safer_mysql/variables.tf
@@ -24,6 +24,12 @@ variable "name" {
   type        = string
 }
 
+variable "random_instance_name" {
+  type        = bool
+  description = "Sets random suffix at the end of the Cloud SQL resource name"
+  default     = false
+}
+
 // required
 variable "database_version" {
   description = "The database version to use"


### PR DESCRIPTION
There is an issue if you would like to create a DB with the same name. With the current approach, you need to change the name every time or you have to work around and use something like `random_id`

> **If I delete my instance, can I reuse the instance name?**
> Yes, but not right away. The instance name is unavailable for up to a week before it can be reused.

More information is here [Managing Your Instances](https://cloud.google.com/sql/faq?hl=en#managing-your-instances)