### PR TITLE
Add an encryption_key_name variable

### DIFF
--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -24,6 +24,7 @@ The following dependency must be available for SQL Server module:
 | disk\_autoresize | Configuration to increase storage size. | bool | `"true"` | no |
 | disk\_size | The disk size for the master instance. | string | `"10"` | no |
 | disk\_type | The disk type for the master instance. | string | `"PD_SSD"` | no |
+| encryption\_key\_name | The full path to the encryption key used for the CMEK disk encryption | string | `"null"` | no |
 | ip\_configuration | The ip configuration for the master instances. | object | `<map>` | no |
 | maintenance\_window\_day | The day of week (1-7) for the master instance maintenance. | number | `"1"` | no |
 | maintenance\_window\_hour | The hour of day (0-23) maintenance window for the master instance maintenance. | number | `"23"` | no |

--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -38,12 +38,13 @@ resource "random_password" "root-password" {
 }
 
 resource "google_sql_database_instance" "default" {
-  provider         = google-beta
-  project          = var.project_id
-  name             = var.random_instance_name ? "${var.name}-${random_id.suffix[0].hex}" : var.name
-  database_version = var.database_version
-  region           = var.region
-  root_password    = coalesce(var.root_password, random_password.root-password.result)
+  provider            = google-beta
+  project             = var.project_id
+  name                = var.random_instance_name ? "${var.name}-${random_id.suffix[0].hex}" : var.name
+  database_version    = var.database_version
+  region              = var.region
+  encryption_key_name = var.encryption_key_name
+  root_password       = coalesce(var.root_password, random_password.root-password.result)
 
   settings {
     tier                        = var.tier

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -224,3 +224,9 @@ variable "module_depends_on" {
   type        = list(any)
   default     = []
 }
+
+variable "encryption_key_name" {
+  description = "The full path to the encryption key used for the CMEK disk encryption"
+  type        = string
+  default     = null
+}

--- a/modules/mssql/versions.tf
+++ b/modules/mssql/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mssql/versions.tf
+++ b/modules/mssql/versions.tf
@@ -17,6 +17,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google-beta = "~> 3.33.0"
+    google-beta = ">= 3.1.0, <4.0.0"
   }
 }

--- a/modules/mssql/versions.tf
+++ b/modules/mssql/versions.tf
@@ -17,6 +17,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google-beta = ">= 3.1.0, <4.0.0"
+    google-beta = ">= 3.10.0, <4.0.0"
   }
 }

--- a/modules/mssql/versions.tf
+++ b/modules/mssql/versions.tf
@@ -17,6 +17,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google-beta = "~> 3.1.0"
+    google-beta = "~> 3.33.0"
   }
 }


### PR DESCRIPTION
This PR fixes #130.
Google-beta provider version updated because the encryption_key_name feature was implemented in [3.9.0](https://github.com/hashicorp/terraform-provider-google-beta/blob/master/CHANGELOG.md#390-february-18-2020)