### PR TITLE
Add mssql example in README and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Copy and paste into your Terraform configuration, insert the variables, and run 
 ```
 module "sql-db" {
   source  = "GoogleCloudPlatform/sql-db/google//modules/mysql"
-  version = "3.1.0"
+  version = "4.0.0"
 }
 ```
 
@@ -90,7 +90,7 @@ or :
 ```
 module "sql-db" {
   source  = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
-  version = "3.1.0"
+  version = "4.0.0"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This module has no root configuration. A module with no root configuration canno
 
 Copy and paste into your Terraform configuration, insert the variables, and run terraform init :
 
+For MySQL :
 ```
 module "sql-db" {
   source  = "GoogleCloudPlatform/sql-db/google//modules/mysql"
@@ -85,7 +86,7 @@ module "sql-db" {
 }
 ```
 
-or :
+or for PostgreSQL :
 
 ```
 module "sql-db" {
@@ -93,6 +94,16 @@ module "sql-db" {
   version = "4.0.0"
 }
 ```
+
+or for MSSQL Server :
+
+```
+module "sql-db" {
+  source  = "GoogleCloudPlatform/sql-db/google//modules/mssql"
+  version = "4.0.0"
+}
+```
+
 
 ## Contributing
 

--- a/modules/safer_mysql/README.md
+++ b/modules/safer_mysql/README.md
@@ -67,7 +67,7 @@ You can add the following Cloud IAM snippet to the project policy:
 
 ## Define MySQL users and passwords on your instance
 
-Because Cloud IAM acts as a primary athentication and authorization mechanism,
+Because Cloud IAM acts as a primary authentication and authorization mechanism,
 we can consider MySQL usernames and passwords are a secondary access controls that
 can be used to further restrict access for reliability or safety
 purposes. For example, removing the ability of modifying tables from production


### PR DESCRIPTION
Hi !

First, thanks for your work.

I added a mssql example in the README and I corrected a typo.

I looked at your safer_mysql. Do you know if a safer_postgresql  is possible and if it's possible, are you interessed for a PR about this ?

Thanks ! 
