### PR TITLE
Feature/add deletion protection option

### DIFF
--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -22,6 +22,7 @@ The following dependency must be available for SQL Server module:
 | db\_collation | The collation for the default database. Example: 'en_US.UTF8' | string | `""` | no |
 | db\_name | The name of the default database to create | string | `"default"` | no |
 | delete\_timeout | The optional timout that is applied to limit long database deletes. | string | `"30m"` | no |
+| deletion\_protection | Enable or disable deletion_protection parameter to allow Terraform the destroy actions | bool | `"true"` | no |
 | disk\_autoresize | Configuration to increase storage size. | bool | `"true"` | no |
 | disk\_size | The disk size for the master instance. | string | `"10"` | no |
 | disk\_type | The disk type for the master instance. | string | `"PD_SSD"` | no |

--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -45,6 +45,7 @@ resource "google_sql_database_instance" "default" {
   region              = var.region
   encryption_key_name = var.encryption_key_name
   root_password       = coalesce(var.root_password, random_password.root-password.result)
+  deletion_protection = var.deletion_protection
 
   settings {
     tier                        = var.tier

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -246,3 +246,9 @@ variable "encryption_key_name" {
   type        = string
   default     = null
 }
+
+variable "deletion_protection" {
+  description = "Enable or disable deletion_protection parameter to allow Terraform the destroy actions"
+  type        = bool
+  default     = true
+}

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -20,6 +20,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | db\_collation | The collation for the default database. Example: 'utf8_general_ci' | string | `""` | no |
 | db\_name | The name of the default database to create | string | `"default"` | no |
 | delete\_timeout | The optional timout that is applied to limit long database deletes. | string | `"10m"` | no |
+| deletion\_protection | Enable or disable deletion_protection parameter to allow Terraform the destroy actions | bool | `"true"` | no |
 | disk\_autoresize | Configuration to increase storage size | bool | `"true"` | no |
 | disk\_size | The disk size for the master instance | number | `"10"` | no |
 | disk\_type | The disk type for the master instance. | string | `"PD_SSD"` | no |

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -46,6 +46,7 @@ resource "google_sql_database_instance" "default" {
   database_version    = var.database_version
   region              = var.region
   encryption_key_name = var.encryption_key_name
+  deletion_protection = var.deletion_protection
 
   settings {
     tier                        = var.tier

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -279,3 +279,9 @@ variable "module_depends_on" {
   type        = list(any)
   default     = []
 }
+
+variable "deletion_protection" {
+  description = "Enable or disable deletion_protection parameter to allow Terraform the destroy actions"
+  type        = bool
+  default     = true
+}

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -19,6 +19,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | db\_collation | The collation for the default database. Example: 'en_US.UTF8' | string | `""` | no |
 | db\_name | The name of the default database to create | string | `"default"` | no |
 | delete\_timeout | The optional timout that is applied to limit long database deletes. | string | `"10m"` | no |
+| deletion\_protection | Enable or disable deletion_protection parameter to allow Terraform the destroy actions | bool | `"true"` | no |
 | disk\_autoresize | Configuration to increase storage size. | bool | `"true"` | no |
 | disk\_size | The disk size for the master instance. | string | `"10"` | no |
 | disk\_type | The disk type for the master instance. | string | `"PD_SSD"` | no |

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -41,6 +41,7 @@ resource "google_sql_database_instance" "default" {
   database_version    = var.database_version
   region              = var.region
   encryption_key_name = var.encryption_key_name
+  deletion_protection = var.deletion_protection
 
   settings {
     tier              = var.tier

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -262,3 +262,8 @@ variable "module_depends_on" {
   default     = []
 }
 
+variable "deletion_protection" {
+  description = "Enable or disable deletion_protection parameter to allow Terraform the destroy actions"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Added a _deletetion_protection_ variable to all modules. Default value: _true_.

This will allow a more easy way to delete managed databases. The default value is the same I found in the _terraform-provider-google_ to follow the same behaviour.
