### PR TITLE
Zone structure fixes

### DIFF
--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -43,7 +43,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | user\_labels | The key/value labels for the master instances. | map(string) | `<map>` | no |
 | user\_name | The name of the default user | string | `"default"` | no |
 | user\_password | The password for the default user. If not set, a random one will be generated and available in the generated_user_password output variable. | string | `""` | no |
-| zone | The zone for the master instance, it should be something like: `a`, `c`. | string | n/a | yes |
+| zone | The zone for the master instance, it should be something like: `us-central1-a`, `us-east1-c`. | string | n/a | yes |
 
 ## Outputs
 

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -95,7 +95,7 @@ resource "google_sql_database_instance" "default" {
     }
 
     location_preference {
-      zone = "${var.region}-${var.zone}"
+      zone = var.zone
     }
 
     maintenance_window {

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -51,7 +51,7 @@ variable "tier" {
 }
 
 variable "zone" {
-  description = "The zone for the master instance, it should be something like: `a`, `c`."
+  description = "The zone for the master instance, it should be something like: `us-central1-a`, `us-east1-c`."
   type        = string
 }
 

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -41,7 +41,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | user\_labels | The key/value labels for the master instances. | map(string) | `<map>` | no |
 | user\_name | The name of the default user | string | `"default"` | no |
 | user\_password | The password for the default user. If not set, a random one will be generated and available in the generated_user_password output variable. | string | `""` | no |
-| zone | The zone for the master instance, it should be something like: `a`, `c`. | string | n/a | yes |
+| zone | The zone for the master instance, it should be something like: `us-central1-a`, `us-east1-c`. | string | n/a | yes |
 
 ## Outputs
 

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -91,7 +91,7 @@ resource "google_sql_database_instance" "default" {
     user_labels = var.user_labels
 
     location_preference {
-      zone = "${var.region}-${var.zone}"
+      zone = var.zone
     }
 
     maintenance_window {

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -51,7 +51,7 @@ variable "tier" {
 
 variable "zone" {
   type        = string
-  description = "The zone for the master instance, it should be something like: `a`, `c`."
+  description = "The zone for the master instance, it should be something like: `us-central1-a`, `us-east1-c`."
 }
 
 variable "activation_policy" {


### PR DESCRIPTION
This PR cleans up previous changes in the expected structure of the zone variable. 

This [commit](https://github.com/terraform-google-modules/terraform-google-sql-db/commit/5e1ae20e5b7efdbb35f733897f5a4378389337d3) changed the expected form of the zone variable but didn't change it in all uses of the variable and didn't update documentation. 