### PR TITLE
Have random name propagate to replicas also

### DIFF
--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -38,6 +38,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | read\_replica\_name\_suffix | The optional suffix to add to the read instance name | string | `""` | no |
 | read\_replicas | List of read replicas to create | object | `<list>` | no |
 | region | The region of the Cloud SQL resources | string | `"us-central1"` | no |
+| replica\_random\_instance\_name | Sets random suffix at the end of the Cloud SQL replicas name | bool | `"false"` | no |
 | tier | The tier for the master instance. | string | `"db-n1-standard-1"` | no |
 | update\_timeout | The optional timout that is applied to limit long database updates. | string | `"10m"` | no |
 | user\_host | The host for the default user | string | `"%"` | no |

--- a/modules/mysql/read_replica.tf
+++ b/modules/mysql/read_replica.tf
@@ -18,11 +18,11 @@ locals {
   replicas = {
     for x in var.read_replicas : "${var.name}-replica${var.read_replica_name_suffix}${x.name}" => x
   }
-  replica_suffix = var.random_instance_name ? "-${random_id.replica-suffix[0].hex}" : ""
+  replica_suffix = var.replica_random_instance_name ? "-${random_id.replica-suffix[0].hex}" : ""
 }
 
 resource random_id replica-suffix {
-  count       = var.random_instance_name ? 1 : 0
+  count       = var.replica_random_instance_name ? 1 : 0
   byte_length = 4
 }
 

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -194,6 +194,12 @@ variable "read_replica_name_suffix" {
   default     = ""
 }
 
+variable "replica_random_instance_name" {
+  description = "Sets random suffix at the end of the Cloud SQL replicas name"
+  type        = bool
+  default     = false
+}
+
 variable "db_name" {
   description = "The name of the default database to create"
   type        = string

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -37,6 +37,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | read\_replica\_name\_suffix | The optional suffix to add to the read instance name | string | `""` | no |
 | read\_replicas | List of read replicas to create | object | `<list>` | no |
 | region | The region of the Cloud SQL resources | string | `"us-central1"` | no |
+| replica\_random\_instance\_name | Sets random suffix at the end of the Cloud SQL replicas name | bool | `"false"` | no |
 | tier | The tier for the master instance. | string | `"db-f1-micro"` | no |
 | update\_timeout | The optional timout that is applied to limit long database updates. | string | `"10m"` | no |
 | user\_labels | The key/value labels for the master instances. | map(string) | `<map>` | no |

--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -18,17 +18,18 @@ locals {
   replicas = {
     for x in var.read_replicas : "${var.name}-replica${var.read_replica_name_suffix}${x.name}" => x
   }
-  replica_suffix = var.random_instance_name ? random_id.replica-suffix.hex : ""
+  replica_suffix = var.random_instance_name ? "-${random_id.replica-suffix[0].hex}"" : ""
 }
 
 resource random_id replica-suffix {
+  count = var.random_instance_name ? 1 : 0
   byte_length = 8
 }
 
 resource "google_sql_database_instance" "replicas" {
   for_each             = local.replicas
   project              = var.project_id
-  name                 = "${local.master_instance_name}-replica${var.read_replica_name_suffix}${each.value.name}"
+  name                 = "${local.master_instance_name}-replica${var.read_replica_name_suffix}${each.value.name}${replica_suffix}"
   database_version     = var.database_version
   region               = join("-", slice(split("-", lookup(each.value, "zone", var.zone)), 0, 2))
   master_instance_name = google_sql_database_instance.default.name

--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -18,7 +18,7 @@ locals {
   replicas = {
     for x in var.read_replicas : "${var.name}-replica${var.read_replica_name_suffix}${x.name}" => x
   }
-  replica_suffix = var.random_instance_name ? "-${random_id.replica-suffix[0].hex}"" : ""
+  replica_suffix = var.random_instance_name ? "-${random_id.replica-suffix[0].hex}" : ""
 }
 
 resource random_id replica-suffix {

--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -22,7 +22,7 @@ locals {
 }
 
 resource random_id replica-suffix {
-  count       = var.random_instance_name ? 1 : 0
+  count       = var.replica_random_instance_name ? 1 : 0
   byte_length = 4
 }
 

--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -18,7 +18,7 @@ locals {
   replicas = {
     for x in var.read_replicas : "${var.name}-replica${var.read_replica_name_suffix}${x.name}" => x
   }
-  replica_suffix = var.random_instance_name ? "-${random_id.replica-suffix[0].hex}" : ""
+  replica_suffix = var.replica_random_instance_name ? "-${random_id.replica-suffix[0].hex}" : ""
 }
 
 resource random_id replica-suffix {

--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -18,6 +18,11 @@ locals {
   replicas = {
     for x in var.read_replicas : "${var.name}-replica${var.read_replica_name_suffix}${x.name}" => x
   }
+  replica_suffix = var.random_instance_name ? random_id.replica-suffix.hex : ""
+}
+
+resource random_id replica-suffix {
+  byte_length = 8
 }
 
 resource "google_sql_database_instance" "replicas" {

--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -22,8 +22,8 @@ locals {
 }
 
 resource random_id replica-suffix {
-  count = var.random_instance_name ? 1 : 0
-  byte_length = 8
+  count       = var.random_instance_name ? 1 : 0
+  byte_length = 4
 }
 
 resource "google_sql_database_instance" "replicas" {

--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -29,7 +29,7 @@ resource random_id replica-suffix {
 resource "google_sql_database_instance" "replicas" {
   for_each             = local.replicas
   project              = var.project_id
-  name                 = "${local.master_instance_name}-replica${var.read_replica_name_suffix}${each.value.name}${replica_suffix}"
+  name                 = "${local.master_instance_name}-replica${var.read_replica_name_suffix}${each.value.name}${local.replica_suffix}"
   database_version     = var.database_version
   region               = join("-", slice(split("-", lookup(each.value, "zone", var.zone)), 0, 2))
   master_instance_name = google_sql_database_instance.default.name

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -185,6 +185,12 @@ variable "read_replica_name_suffix" {
   default     = ""
 }
 
+variable "replica_random_instance_name" {
+  description = "Sets random suffix at the end of the Cloud SQL replicas name"
+  type        = bool
+  default     = false
+}
+
 variable "db_name" {
   description = "The name of the default database to create"
   type        = string


### PR DESCRIPTION
Not able to send a random replica name through to replicas since they are using for each now in version 4.*.

This piggybacks on the random_instance_name variable to also append random suffix to replica names. This is needed to be able to bring replica's up and down within 24 hours due to GCP naming conflict limitation. 

Open to creating a new variable for replicas (replica_random_instance_name?), or else this is backwards incompatible for users with existing replicas and random_instance_name set to true. 