### PR TITLE
Add variable for managing the creation of the default database and user

### DIFF
--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -23,6 +23,8 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | disk\_autoresize | Configuration to increase storage size. | bool | `"true"` | no |
 | disk\_size | The disk size for the master instance. | string | `"10"` | no |
 | disk\_type | The disk type for the master instance. | string | `"PD_SSD"` | no |
+| enable\_default\_db | Enable or disable the creation of the default database | bool | `"true"` | no |
+| enable\_default\_user | Enable or disable the creation of the default user | bool | `"true"` | no |
 | encryption\_key\_name | The full path to the encryption key used for the CMEK disk encryption | string | `"null"` | no |
 | ip\_configuration | The ip configuration for the master instances. | object | `<map>` | no |
 | maintenance\_window\_day | The day of week (1-7) for the master instance maintenance. | number | `"1"` | no |

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -117,6 +117,7 @@ resource "google_sql_database_instance" "default" {
 }
 
 resource "google_sql_database" "default" {
+  count      = var.enable_default_db ? 1 : 0
   name       = var.db_name
   project    = var.project_id
   instance   = google_sql_database_instance.default.name
@@ -145,6 +146,7 @@ resource "random_id" "user-password" {
 }
 
 resource "google_sql_user" "default" {
+  count      = var.enable_default_user ? 1 : 0
   name       = var.user_name
   project    = var.project_id
   instance   = google_sql_database_instance.default.name

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -275,3 +275,15 @@ variable "read_replica_deletion_protection" {
   type        = bool
   default     = false
 }
+
+variable "enable_default_db" {
+  description = "Enable or disable the creation of the default database"
+  type        = bool
+  default     = true
+}
+
+variable "enable_default_user" {
+  description = "Enable or disable the creation of the default user"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Hello,
I'd like to add the option to enable or disable the creation of the default database and user.

At the moment if I delete the default DB from the google console, terraform recreate it at the next run.