### PR TITLE
Support terraform 0.14+

### DIFF
--- a/examples/mysql-ha/versions.tf
+++ b/examples/mysql-ha/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
 }

--- a/examples/mysql-ha/versions.tf
+++ b/examples/mysql-ha/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
 }

--- a/examples/mysql-private/versions.tf
+++ b/examples/mysql-private/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
 }

--- a/examples/mysql-private/versions.tf
+++ b/examples/mysql-private/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
 }

--- a/examples/mysql-public/versions.tf
+++ b/examples/mysql-public/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
 }

--- a/examples/mysql-public/versions.tf
+++ b/examples/mysql-public/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
 }

--- a/examples/postgresql-ha/versions.tf
+++ b/examples/postgresql-ha/versions.tf
@@ -15,6 +15,6 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
 }
 

--- a/examples/postgresql-ha/versions.tf
+++ b/examples/postgresql-ha/versions.tf
@@ -15,6 +15,6 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
 }
 

--- a/examples/postgresql-public/versions.tf
+++ b/examples/postgresql-public/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
 }

--- a/examples/postgresql-public/versions.tf
+++ b/examples/postgresql-public/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
 }

--- a/modules/mysql/versions.tf
+++ b/modules/mysql/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
   required_providers {
     google = "~> 3.22"
     null   = "~> 2.1"

--- a/modules/mysql/versions.tf
+++ b/modules/mysql/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
   required_providers {
     google = "~> 3.22"
     null   = "~> 2.1"

--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
   required_providers {
     google = "~> 3.5"
     null   = "~> 2.1"

--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
   required_providers {
     google = "~> 3.5"
     null   = "~> 2.1"

--- a/modules/private_service_access/versions.tf
+++ b/modules/private_service_access/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
   required_providers {
     google      = "~> 3.5"
     google-beta = "~> 3.5"

--- a/modules/private_service_access/versions.tf
+++ b/modules/private_service_access/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
   required_providers {
     google      = "~> 3.5"
     google-beta = "~> 3.5"

--- a/modules/safer_mysql/versions.tf
+++ b/modules/safer_mysql/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
 }

--- a/modules/safer_mysql/versions.tf
+++ b/modules/safer_mysql/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
 }

--- a/test/fixtures/mysql-ha/versions.tf
+++ b/test/fixtures/mysql-ha/versions.tf
@@ -15,6 +15,6 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
 }
 

--- a/test/fixtures/mysql-ha/versions.tf
+++ b/test/fixtures/mysql-ha/versions.tf
@@ -15,6 +15,6 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
 }
 

--- a/test/fixtures/mysql-private/versions.tf
+++ b/test/fixtures/mysql-private/versions.tf
@@ -15,6 +15,6 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
 }
 

--- a/test/fixtures/mysql-private/versions.tf
+++ b/test/fixtures/mysql-private/versions.tf
@@ -15,6 +15,6 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
 }
 

--- a/test/fixtures/mysql-public/versions.tf
+++ b/test/fixtures/mysql-public/versions.tf
@@ -15,6 +15,6 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
 }
 

--- a/test/fixtures/mysql-public/versions.tf
+++ b/test/fixtures/mysql-public/versions.tf
@@ -15,6 +15,6 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
 }
 

--- a/test/fixtures/postgresql-ha/versions.tf
+++ b/test/fixtures/postgresql-ha/versions.tf
@@ -15,6 +15,6 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
 }
 

--- a/test/fixtures/postgresql-ha/versions.tf
+++ b/test/fixtures/postgresql-ha/versions.tf
@@ -15,6 +15,6 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
 }
 

--- a/test/fixtures/postgresql-public/versions.tf
+++ b/test/fixtures/postgresql-public/versions.tf
@@ -15,6 +15,6 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
 }
 

--- a/test/fixtures/postgresql-public/versions.tf
+++ b/test/fixtures/postgresql-public/versions.tf
@@ -15,6 +15,6 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
 }
 

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6, <0.15"
 }

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.15"
+  required_version = ">=0.12.6"
 }


### PR DESCRIPTION
This PR adds support for terraform 0.14.

Note: it is considered a "best practice" to not define upper limits for terraform core version in reusable modules:

> # Terraform Core and Provider Versions
> Reusable modules should constrain *only their minimum allowed versions of Terraform* and providers, such as >= 0.12.0. This helps avoid known incompatibilities, while allowing the user of the module flexibility to upgrade to newer versions of Terraform without altering the module.

See https://www.terraform.io/docs/configuration/version-constraints.html#terraform-core-and-provider-versions