### PR TITLE
feat: allow multiple google_compute_global_address per vpc - reloaded

### DIFF
--- a/modules/private_service_access/README.md
+++ b/modules/private_service_access/README.md
@@ -18,6 +18,7 @@ that are connected to the same VPC.
 | address | First IP address of the IP range to allocate to CLoud SQL instances and other Private Service Access services. If not set, GCP will pick a valid one for you. | string | `""` | no |
 | ip\_version | IP Version for the allocation. Can be IPV4 or IPV6. | string | `""` | no |
 | labels | The key/value labels for the IP range allocated to the peered network. | map(string) | `<map>` | no |
+| name\_suffix | An optional suffix added to resource names. | string | `""` | no |
 | prefix\_length | Prefix length of the IP range reserved for Cloud SQL instances and other Private Service Access services. Defaults to /16. | number | `"16"` | no |
 | project\_id | The project ID of the VPC network to peer. This can be a shared VPC host projec. | string | n/a | yes |
 | vpc\_network | Name of the VPC network to peer. | string | n/a | yes |

--- a/modules/private_service_access/main.tf
+++ b/modules/private_service_access/main.tf
@@ -20,6 +20,10 @@ data "google_compute_network" "main" {
 
 }
 
+locals {
+  name_suffix = length(var.name_suffix) == 0 ? "" : "-${var.name_suffix}"
+}
+
 // We define a VPC peering subnet that will be peered with the
 // Cloud SQL instance network. The Cloud SQL instance will
 // have a private IP within the provided range.
@@ -27,7 +31,7 @@ data "google_compute_network" "main" {
 resource "google_compute_global_address" "google-managed-services-range" {
   provider      = google-beta
   project       = var.project_id
-  name          = "google-managed-services-${var.vpc_network}"
+  name          = "google-managed-services-${var.vpc_network}${local.name_suffix}"
   purpose       = "VPC_PEERING"
   address       = var.address
   prefix_length = var.prefix_length

--- a/modules/private_service_access/variables.tf
+++ b/modules/private_service_access/variables.tf
@@ -53,3 +53,4 @@ variable "name_suffix" {
   type        = string
   default     = ""
 }
+

--- a/modules/private_service_access/variables.tf
+++ b/modules/private_service_access/variables.tf
@@ -47,3 +47,9 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "name_suffix" {
+  description = "An optional suffix added to resource names."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
I open this PR in reference to #158 and #159 from last year. It turned out that private service connections needs to be created for each region and Cloud SQL type peered with the VPC:

> Cloud SQL allocates a /24 subnet from the private services access IP range for each combination of region and database type. For example, placing MySQL instances in two regions requires that the allocated IP address range contain at least two available subnets of size /24, and deploying MySQL and PostgreSQL in two regions requires four available subnets of size /24. SQL Server instances may share the same subnet with MySQL instances in a region.

Please have a look at https://cloud.google.com/sql/docs/mysql/private-ip#network_requirements .

With the current implementation of the `private_service_access` this is not possible as the name of the `google_compute_global_address` resource is generated from the VPC network. I added a suffix to overcome this problem. This way multiple instances of the `private_service_access` can be deployed for a VPC making it possible to deploy multiple Cloud SQL types (e.g. MSSQL and postgresql).