### PR TITLE
Consistent behaviour for region, zone, and database_version across modules

### DIFF
--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -36,14 +36,14 @@ The following dependency must be available for SQL Server module:
 | pricing\_plan | The pricing plan for the master instance. | string | `"PER_USE"` | no |
 | project\_id | The project ID to manage the Cloud SQL resources | string | n/a | yes |
 | random\_instance\_name | Sets random suffix at the end of the Cloud SQL resource name | bool | `"false"` | no |
-| region | The region of the Cloud SQL resources | string | `"us-central1"` | no |
+| region | The region of the Cloud SQL resources | string | n/a | yes |
 | root\_password | MSSERVER password for the root user. If not set, a random one will be generated and available in the root_password output variable. | string | `""` | no |
 | tier | The tier for the master instance. | string | `"db-custom-2-3840"` | no |
 | update\_timeout | The optional timeout that is applied to limit long database updates. | string | `"15m"` | no |
 | user\_labels | The key/value labels for the master instances. | map(string) | `<map>` | no |
 | user\_name | The name of the default user | string | `"default"` | no |
 | user\_password | The password for the default user. If not set, a random one will be generated and available in the generated_user_password output variable. | string | `""` | no |
-| zone | The zone for the master instance. | string | `"us-central1-a"` | no |
+| zone | The zone for the master instance. | string | n/a | yes |
 
 ## Outputs
 

--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -17,7 +17,7 @@ The following dependency must be available for SQL Server module:
 | backup\_configuration | The database backup configuration. | object | `<map>` | no |
 | create\_timeout | The optional timeout that is applied to limit long database creates. | string | `"15m"` | no |
 | database\_flags | The database flags for the master instance. See [more details](https://cloud.google.com/sql/docs/sqlserver/flags) | object | `<list>` | no |
-| database\_version | The database version to use: SQLSERVER_2017_STANDARD, SQLSERVER_2017_ENTERPRISE, SQLSERVER_2017_EXPRESS, or SQLSERVER_2017_WEB | string | `"SQLSERVER_2017_STANDARD"` | no |
+| database\_version | The database version to use: SQLSERVER_2017_STANDARD, SQLSERVER_2017_ENTERPRISE, SQLSERVER_2017_EXPRESS, or SQLSERVER_2017_WEB | string | n/a | yes |
 | db\_charset | The charset for the default database | string | `""` | no |
 | db\_collation | The collation for the default database. Example: 'en_US.UTF8' | string | `""` | no |
 | db\_name | The name of the default database to create | string | `"default"` | no |

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -37,11 +37,9 @@ variable "database_version" {
   default     = "SQLSERVER_2017_STANDARD"
 }
 
-// required
 variable "region" {
   type        = string
   description = "The region of the Cloud SQL resources"
-  default     = "us-central1"
 }
 
 variable "tier" {
@@ -53,7 +51,6 @@ variable "tier" {
 variable "zone" {
   type        = string
   description = "The zone for the master instance."
-  default     = "us-central1-a"
 }
 
 variable "activation_policy" {

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -30,11 +30,9 @@ variable "random_instance_name" {
   default     = false
 }
 
-// required
 variable "database_version" {
   description = "The database version to use: SQLSERVER_2017_STANDARD, SQLSERVER_2017_ENTERPRISE, SQLSERVER_2017_EXPRESS, or SQLSERVER_2017_WEB"
   type        = string
-  default     = "SQLSERVER_2017_STANDARD"
 }
 
 variable "region" {

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -39,7 +39,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | read\_replica\_deletion\_protection | Used to block Terraform from deleting replica SQL Instances. | bool | `"false"` | no |
 | read\_replica\_name\_suffix | The optional suffix to add to the read instance name | string | `""` | no |
 | read\_replicas | List of read replicas to create | object | `<list>` | no |
-| region | The region of the Cloud SQL resources | string | `"us-central1"` | no |
+| region | The region of the Cloud SQL resources | string | n/a | yes |
 | tier | The tier for the master instance. | string | `"db-n1-standard-1"` | no |
 | update\_timeout | The optional timout that is applied to limit long database updates. | string | `"10m"` | no |
 | user\_host | The host for the default user | string | `"%"` | no |

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -36,11 +36,9 @@ variable "database_version" {
   type        = string
 }
 
-// required
 variable "region" {
   description = "The region of the Cloud SQL resources"
   type        = string
-  default     = "us-central1"
 }
 
 // Master

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -30,7 +30,6 @@ variable "random_instance_name" {
   default     = false
 }
 
-// required
 variable "database_version" {
   description = "The database version to use"
   type        = string

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -38,7 +38,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | read\_replica\_deletion\_protection | Used to block Terraform from deleting replica SQL Instances. | bool | `"false"` | no |
 | read\_replica\_name\_suffix | The optional suffix to add to the read instance name | string | `""` | no |
 | read\_replicas | List of read replicas to create | object | `<list>` | no |
-| region | The region of the Cloud SQL resources | string | `"us-central1"` | no |
+| region | The region of the Cloud SQL resources | string | n/a | yes |
 | tier | The tier for the master instance. | string | `"db-f1-micro"` | no |
 | update\_timeout | The optional timout that is applied to limit long database updates. | string | `"10m"` | no |
 | user\_labels | The key/value labels for the master instances. | map(string) | `<map>` | no |

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -30,7 +30,6 @@ variable "random_instance_name" {
   default     = false
 }
 
-// required
 variable "database_version" {
   description = "The database version to use"
   type        = string

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -36,11 +36,9 @@ variable "database_version" {
   type        = string
 }
 
-// required
 variable "region" {
   type        = string
   description = "The region of the Cloud SQL resources"
-  default     = "us-central1"
 }
 
 variable "tier" {

--- a/modules/safer_mysql/variables.tf
+++ b/modules/safer_mysql/variables.tf
@@ -30,7 +30,6 @@ variable "random_instance_name" {
   default     = false
 }
 
-// required
 variable "database_version" {
   description = "The database version to use"
   type        = string

--- a/modules/safer_mysql/variables.tf
+++ b/modules/safer_mysql/variables.tf
@@ -36,7 +36,6 @@ variable "database_version" {
   type        = string
 }
 
-// required
 variable "region" {
   description = "The region of the Cloud SQL resources"
   type        = string


### PR DESCRIPTION
Addresses https://github.com/terraform-google-modules/terraform-google-sql-db/issues/179.

As per the comments in each `variables.tf`, this PR makes the following variables required across every SQL module - `region`, `zone`, and `database_version`, addressing the following inconsistencies: 

- `mssql` has a default database version, but `mysql`, `safer_mysql`, and `postgresql` do not.
- `mysql` and `postgresql` do not default the zone, but do default the region.
- `mssql` default both the zone and region.
- `safer_mysql` does not default the zone nor the region.

I don't know how y'all do semver, but this would likely merit a bump to version 5.0.

