### PR TITLE
Adding conditional flag to enable read replica if required

### DIFF
--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -21,6 +21,7 @@ locals {
 }
 
 resource "google_sql_database_instance" "replicas" {
+  count = var.read_replica == true ? 1 : 0
   for_each             = local.replicas
   project              = var.project_id
   name                 = "${local.master_instance_name}-replica${var.read_replica_name_suffix}${each.value.name}"

--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 resource "google_sql_database_instance" "replicas" {
-  count = var.read_replicas == true ? 1 : 0
+  count = var.read_replica == true ? 1 : 0
   for_each             = local.replicas
   project              = var.project_id
   name                 = "${local.master_instance_name}-replica${var.read_replica_name_suffix}${each.value.name}"

--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 resource "google_sql_database_instance" "replicas" {
-  count = var.read_replica == true ? 1 : 0
+  count = var.read_replica_enable == true ? 1 : 0
   for_each             = local.replicas
   project              = var.project_id
   name                 = "${local.master_instance_name}-replica${var.read_replica_name_suffix}${each.value.name}"

--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 resource "google_sql_database_instance" "replicas" {
-  count = var.read_replica == true ? 1 : 0
+  count = var.read_replicas == true ? 1 : 0
   for_each             = local.replicas
   project              = var.project_id
   name                 = "${local.master_instance_name}-replica${var.read_replica_name_suffix}${each.value.name}"

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -155,6 +155,10 @@ variable "ip_configuration" {
 }
 
 // Read Replicas
+variable "read_replica" {
+  description = "Flag to determine if read replica is required"
+}
+
 variable "read_replicas" {
   description = "List of read replicas to create"
   type = list(object({

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -155,7 +155,7 @@ variable "ip_configuration" {
 }
 
 // Read Replicas
-variable "read_replica" {
+variable "read_replica_enable" {
   description = "Flag to determine if read replica is required"
 }
 


### PR DESCRIPTION
HI team,

We are using terraform open-source terraform module for creating postgres sql instance...where we are using same code for creating postgres sql instance in multiple environments like dev, staging & production. 
Where we require read replica instance only for production, it's not needed for dev & staging. With the current master code we are not able to restrict this approach, so I have added a count condition with a boolean flag. Please have a review on this PR and let me know if this make sense. Also let me know if i have missed something from my end.