### PR TITLE
feat!: extended the postgresql module to accept IAM users and services accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
+### [5.0.1](https://www.github.com/terraform-google-modules/terraform-google-sql-db/compare/v5.0.0...v5.0.1) (2021-04-22)
+
+
+### Bug Fixes
+
+* Add outputs for the actual `google_sql_database_instance` resources ([#193](https://www.github.com/terraform-google-modules/terraform-google-sql-db/issues/193)) ([70205b0](https://www.github.com/terraform-google-modules/terraform-google-sql-db/commit/70205b0023df9ff68783fc1b7a5c4adf2dda90ef))
+
 ## [5.0.0](https://www.github.com/terraform-google-modules/terraform-google-sql-db/compare/v4.5.0...v5.0.0) (2021-03-25)
 
 

--- a/examples/postgresql-public-iam/README.md
+++ b/examples/postgresql-public-iam/README.md
@@ -1,0 +1,40 @@
+# Cloud SQL Database Example
+
+This example shows how to create the public Postgres Cloud SQL database using the Terraform module with IAM accounts.
+
+## Run Terraform
+
+Create resources with terraform:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+To remove all resources created by terraform:
+
+```bash
+terraform destroy
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| authorized\_networks | List of mapped public networks authorized to access to the instances. Default - short range of GCP health-checkers IPs | `list(map(string))` | <pre>[<br>  {<br>    "name": "sample-gcp-health-checkers-range",<br>    "value": "130.211.0.0/28"<br>  }<br>]</pre> | no |
+| db\_name | The name of the SQL Database instance | `string` | `"example-postgres-public"` | no |
+| project\_id | The ID of the project in which resources will be provisioned. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| name | The name for Cloud SQL instance |
+| project\_id | The project to run tests against |
+| psql\_conn | The connection name of the master instance to be used in connection strings |
+| psql\_user\_pass | The password for the default user. If not set, a random one will be generated and available in the generated\_user\_password output variable. |
+| public\_ip\_address | The first public (PRIMARY) IPv4 address assigned for the master instance |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/postgresql-public-iam/main.tf
+++ b/examples/postgresql-public-iam/main.tf
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google" {
+  version = "~> 3.22"
+}
+
+provider "google-beta" {
+  version = "~> 3.5"
+}
+
+provider "null" {
+  version = "~> 2.1"
+}
+
+provider "random" {
+  version = "~> 2.2"
+}
+
+module "postgresql-db" {
+  source               = "../../modules/postgresql"
+  name                 = var.db_name
+  random_instance_name = true
+  database_version     = "POSTGRES_9_6"
+  project_id           = var.project_id
+  zone                 = "us-central1-c"
+  region               = "us-central1"
+  tier                 = "db-f1-micro"
+
+  deletion_protection = false
+
+  ip_configuration = {
+    ipv4_enabled        = true
+    private_network     = null
+    require_ssl         = true
+    authorized_networks = var.authorized_networks
+  }
+
+  database_flags = [
+    {
+      name  = "cloudsql.iam_authentication"
+      value = "On"
+    },
+  ]
+
+  additional_users = [
+    {
+      name     = "tftest2"
+      password = "abcdefg"
+      host     = "localhost"
+    },
+    {
+      name     = "tftest3"
+      password = "abcdefg"
+      host     = "localhost"
+    },
+  ]
+
+  # Supports creation of both IAM Users and IAM Service Accounts
+  iam_users = [
+    {
+      name          = "cloudsql-pg-sa-01"
+      description   = "A service account to access postgres databases 01"
+      is_account_sa = true
+    },
+    {
+      name          = "dbadmin@goosecorp.org"
+      description   = null
+      is_account_sa = false
+    },
+  ]
+}

--- a/examples/postgresql-public-iam/outputs.tf
+++ b/examples/postgresql-public-iam/outputs.tf
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "project_id" {
+  value       = var.project_id
+  description = "The project to run tests against"
+}
+
+output "name" {
+  description = "The name for Cloud SQL instance"
+  value       = module.postgresql-db.instance_name
+}
+
+output "psql_conn" {
+  value       = module.postgresql-db.instance_connection_name
+  description = "The connection name of the master instance to be used in connection strings"
+}
+
+output "psql_user_pass" {
+  value       = module.postgresql-db.generated_user_password
+  description = "The password for the default user. If not set, a random one will be generated and available in the generated_user_password output variable."
+}
+
+output "public_ip_address" {
+  description = "The first public (PRIMARY) IPv4 address assigned for the master instance"
+  value       = module.postgresql-db.public_ip_address
+}

--- a/examples/postgresql-public-iam/variables.tf
+++ b/examples/postgresql-public-iam/variables.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which resources will be provisioned."
+  type        = string
+}
+
+variable "authorized_networks" {
+  default = [{
+    name  = "sample-gcp-health-checkers-range"
+    value = "130.211.0.0/28"
+  }]
+  type        = list(map(string))
+  description = "List of mapped public networks authorized to access to the instances. Default - short range of GCP health-checkers IPs"
+}
+
+variable "db_name" {
+  description = "The name of the SQL Database instance"
+  default     = "example-postgres-public"
+}
+

--- a/examples/postgresql-public-iam/versions.tf
+++ b/examples/postgresql-public-iam/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">=0.12.6"
+}

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -40,6 +40,11 @@ suites:
       name: terraform
       root_module_directory: test/fixtures/postgresql-public
       command_timeout: 1800
+  - name: postgresql-public-iam
+    driver:
+      name: terraform
+      root_module_directory: test/fixtures/postgresql-public-iam
+      command_timeout: 1800
   - name: mysql-private
     driver:
       name: terraform

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -27,8 +27,7 @@ verifier:
   name: terraform
   systems:
     - name: system
-      backend: gcp
-      shell: true
+      backend: local
 
 suites:
   - name: mysql-public

--- a/modules/mssql/versions.tf
+++ b/modules/mssql/versions.tf
@@ -25,7 +25,7 @@ terraform {
   }
 
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-sql-db:mssql/v5.0.0"
+    module_name = "blueprints/terraform/terraform-google-sql-db:mssql/v5.0.1"
   }
 
 }

--- a/modules/mysql/versions.tf
+++ b/modules/mysql/versions.tf
@@ -32,7 +32,7 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-sql-db:mysql/v5.0.0"
+    module_name = "blueprints/terraform/terraform-google-sql-db:mysql/v5.0.1"
   }
 
 }

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -26,6 +26,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | enable\_default\_db | Enable or disable the creation of the default database | `bool` | `true` | no |
 | enable\_default\_user | Enable or disable the creation of the default user | `bool` | `true` | no |
 | encryption\_key\_name | The full path to the encryption key used for the CMEK disk encryption | `string` | `null` | no |
+| iam\_users | A list of IAM users to be created in your cluster | <pre>list(object({<br>    name          = string<br>    description   = string<br>    is_account_sa = bool<br>  }))</pre> | `[]` | no |
 | insights\_config | The insights\_config settings for the database. | <pre>object({<br>    query_string_length     = number<br>    record_application_tags = bool<br>    record_client_address   = bool<br>  })</pre> | `null` | no |
 | ip\_configuration | The ip configuration for the master instances. | <pre>object({<br>    authorized_networks = list(map(string))<br>    ipv4_enabled        = bool<br>    private_network     = string<br>    require_ssl         = bool<br>  })</pre> | <pre>{<br>  "authorized_networks": [],<br>  "ipv4_enabled": true,<br>  "private_network": null,<br>  "require_ssl": null<br>}</pre> | no |
 | maintenance\_window\_day | The day of week (1-7) for the master instance maintenance. | `number` | `1` | no |

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -12,13 +12,13 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | additional\_users | A list of users to be created in your cluster | <pre>list(object({<br>    name     = string<br>    password = string<br>  }))</pre> | `[]` | no |
 | availability\_type | The availability type for the master instance.This is only used to set up high availability for the PostgreSQL instance. Can be either `ZONAL` or `REGIONAL`. | `string` | `"ZONAL"` | no |
 | backup\_configuration | The backup\_configuration settings subblock for the database setings | <pre>object({<br>    enabled                        = bool<br>    start_time                     = string<br>    location                       = string<br>    point_in_time_recovery_enabled = bool<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "location": null,<br>  "point_in_time_recovery_enabled": false,<br>  "start_time": null<br>}</pre> | no |
-| create\_timeout | The optional timout that is applied to limit long database creates. | `string` | `"10m"` | no |
+| create\_timeout | The optional timout that is applied to limit long database creates. | `string` | `"15m"` | no |
 | database\_flags | The database flags for the master instance. See [more details](https://cloud.google.com/sql/docs/postgres/flags) | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | database\_version | The database version to use | `string` | n/a | yes |
 | db\_charset | The charset for the default database | `string` | `""` | no |
 | db\_collation | The collation for the default database. Example: 'en\_US.UTF8' | `string` | `""` | no |
 | db\_name | The name of the default database to create | `string` | `"default"` | no |
-| delete\_timeout | The optional timout that is applied to limit long database deletes. | `string` | `"10m"` | no |
+| delete\_timeout | The optional timout that is applied to limit long database deletes. | `string` | `"15m"` | no |
 | deletion\_protection | Used to block Terraform from deleting a SQL Instance. | `bool` | `true` | no |
 | disk\_autoresize | Configuration to increase storage size. | `bool` | `true` | no |
 | disk\_size | The disk size for the master instance. | `number` | `10` | no |
@@ -41,7 +41,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | read\_replicas | List of read replicas to create | <pre>list(object({<br>    name            = string<br>    tier            = string<br>    zone            = string<br>    disk_type       = string<br>    disk_autoresize = bool<br>    disk_size       = string<br>    user_labels     = map(string)<br>    database_flags = list(object({<br>      name  = string<br>      value = string<br>    }))<br>    ip_configuration = object({<br>      authorized_networks = list(map(string))<br>      ipv4_enabled        = bool<br>      private_network     = string<br>      require_ssl         = bool<br>    })<br>  }))</pre> | `[]` | no |
 | region | The region of the Cloud SQL resources | `string` | `"us-central1"` | no |
 | tier | The tier for the master instance. | `string` | `"db-f1-micro"` | no |
-| update\_timeout | The optional timout that is applied to limit long database updates. | `string` | `"10m"` | no |
+| update\_timeout | The optional timout that is applied to limit long database updates. | `string` | `"15m"` | no |
 | user\_labels | The key/value labels for the master instances. | `map(string)` | `{}` | no |
 | user\_name | The name of the default user | `string` | `"default"` | no |
 | user\_password | The password for the default user. If not set, a random one will be generated and available in the generated\_user\_password output variable. | `string` | `""` | no |

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -26,6 +26,7 @@ locals {
 
   databases = { for db in var.additional_databases : db.name => db }
   users     = { for u in var.additional_users : u.name => u }
+  iam_users = { for iu in var.iam_users : iu.name => iu }
 }
 
 resource "random_id" "suffix" {
@@ -171,6 +172,45 @@ resource "google_sql_user" "additional_users" {
   password   = lookup(each.value, "password", random_id.user-password.hex)
   instance   = google_sql_database_instance.default.name
   depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
+}
+
+resource "google_sql_user" "iam_account" {
+  for_each = local.iam_users
+  project  = var.project_id
+  name = each.value.is_account_sa ? (
+    trimsuffix(google_service_account.sa[each.value.name].email, ".gserviceaccount.com")
+    ) : (
+    each.value.name
+  )
+  instance = google_sql_database_instance.default.name
+  type     = each.value.is_account_sa ? "CLOUD_IAM_SERVICE_ACCOUNT" : "CLOUD_IAM_USER"
+  depends_on = [
+    null_resource.module_depends_on,
+    google_sql_database_instance.default,
+    google_service_account.sa,
+  ]
+}
+
+resource "google_service_account" "sa" {
+  for_each = {
+    for i in local.iam_users : i.name => i
+    if i.is_account_sa
+  }
+
+  project      = var.project_id
+  account_id   = each.value.name
+  display_name = each.value.description
+}
+
+resource "google_project_iam_member" "iam_binding" {
+  for_each = local.iam_users
+  project  = var.project_id
+  role     = "roles/cloudsql.instanceUser"
+  member = each.value.is_account_sa ? (
+    "serviceAccount:${google_service_account.sa[each.value.name].email}"
+    ) : (
+    "user:${each.value.name}"
+  )
 }
 
 resource "null_resource" "module_depends_on" {

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -247,19 +247,19 @@ variable "additional_users" {
 variable "create_timeout" {
   description = "The optional timout that is applied to limit long database creates."
   type        = string
-  default     = "10m"
+  default     = "15m"
 }
 
 variable "update_timeout" {
   description = "The optional timout that is applied to limit long database updates."
   type        = string
-  default     = "10m"
+  default     = "15m"
 }
 
 variable "delete_timeout" {
   description = "The optional timout that is applied to limit long database deletes."
   type        = string
-  default     = "10m"
+  default     = "15m"
 }
 
 variable "encryption_key_name" {

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -244,6 +244,16 @@ variable "additional_users" {
   default = []
 }
 
+variable "iam_users" {
+  description = "A list of IAM users to be created in your cluster"
+  type = list(object({
+    name          = string
+    description   = string
+    is_account_sa = bool
+  }))
+  default = []
+}
+
 variable "create_timeout" {
   description = "The optional timout that is applied to limit long database creates."
   type        = string

--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -32,7 +32,7 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-sql-db:postgresql/v5.0.0"
+    module_name = "blueprints/terraform/terraform-google-sql-db:postgresql/v5.0.1"
   }
 
 }

--- a/modules/private_service_access/versions.tf
+++ b/modules/private_service_access/versions.tf
@@ -32,11 +32,11 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-sql-db:private_service_access/v5.0.0"
+    module_name = "blueprints/terraform/terraform-google-sql-db:private_service_access/v5.0.1"
   }
 
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-sql-db:private_service_access/v5.0.0"
+    module_name = "blueprints/terraform/terraform-google-sql-db:private_service_access/v5.0.1"
   }
 
 }

--- a/modules/safer_mysql/versions.tf
+++ b/modules/safer_mysql/versions.tf
@@ -25,7 +25,7 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-sql-db:safer_mysql/v5.0.0"
+    module_name = "blueprints/terraform/terraform-google-sql-db:safer_mysql/v5.0.1"
   }
 
 }

--- a/test/fixtures/postgresql-public-iam/main.tf
+++ b/test/fixtures/postgresql-public-iam/main.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "example" {
+  source = "../../../examples/postgresql-public-iam"
+
+  project_id          = var.project_id
+  authorized_networks = var.authorized_networks
+  db_name             = var.db_name
+}

--- a/test/fixtures/postgresql-public-iam/outputs.tf
+++ b/test/fixtures/postgresql-public-iam/outputs.tf
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "project_id" {
+  value       = module.example.project_id
+  description = "The project to run tests against"
+}
+
+output "name" {
+  value       = module.example.name
+  description = "The name for Cloud SQL instance"
+}
+
+output "psql_conn" {
+  value       = module.example.psql_conn
+  description = "The connection name of the master instance to be used in connection strings"
+}
+
+output "psql_user_pass" {
+  value       = module.example.psql_user_pass
+  description = "The password for the default user. If not set, a random one will be generated and available in the generated_user_password output variable."
+}
+
+output "public_ip_address" {
+  description = "The first public (PRIMARY) IPv4 address assigned for the master instance"
+  value       = module.example.public_ip_address
+}
+

--- a/test/fixtures/postgresql-public-iam/variables.tf
+++ b/test/fixtures/postgresql-public-iam/variables.tf
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which resources will be provisioned."
+  type        = string
+}
+
+variable "authorized_networks" {
+  default = [{
+    name  = "sample-gcp-health-checkers-range"
+    value = "130.211.0.0/28"
+  }]
+  type        = list(map(string))
+  description = "List of mapped public networks authorized to access to the instances. Default - short range of GCP health-checkers IPs"
+}
+
+variable "db_name" {
+  description = "The name of the SQL Database instance"
+  default     = "example-postgres-public-iam"
+}

--- a/test/fixtures/postgresql-public-iam/versions.tf
+++ b/test/fixtures/postgresql-public-iam/versions.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">=0.12.6"
+}
+

--- a/test/integration/mssql-ha/controls/mssql.rb
+++ b/test/integration/mssql-ha/controls/mssql.rb
@@ -12,46 +12,118 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'json'
+
 project_id = attribute('project_id')
 basename   = attribute('name')
 authorized_network = attribute('authorized_network')
+region = "us-central1"
 
-describe google_sql_database_instance(project: project_id, database: basename) do
-  let(:expected_settings) {
-    {
-      activation_policy: "ALWAYS",
-      availability_type: "REGIONAL",
-      data_disk_size_gb: 10,
-      data_disk_type: "PD_SSD",
-      kind: "sql#settings",
-      pricing_plan: "PER_USE",
-      replication_type: "SYNCHRONOUS",
-      storage_auto_resize: true,
-      storage_auto_resize_limit: 0,
-      tier: "db-custom-2-13312",
-    }
-  }
-  let(:settings)                { subject.settings.item }
-  let(:backup_configuration)    { settings[:backup_configuration] }
-  let(:ip_configuration)        { settings[:ip_configuration] }
-  let(:location_preference)     { settings[:location_preference] }
-  let(:maintenance_window)      { settings[:maintenance_window] }
-  let(:user_labels)             { settings[:user_labels] }
+activation_policy = "ALWAYS"
+availability_type = "REGIONAL"
+data_disk_size_gb = 10
+data_disk_type = "PD_SSD"
+kind = "sql#settings"
+pricing_plan = "PER_USE"
+replication_type = "SYNCHRONOUS"
+storage_auto_resize = true
+storage_auto_resize_limit = 0
+tier = "db-custom-2-13312"
 
-  its(:backend_type)     { should eq 'SECOND_GEN' }
-  its(:database_version) { should eq 'SQLSERVER_2017_STANDARD' }
-  its(:state)            { should eq 'RUNNABLE' }
-  its(:region)           { should eq 'us-central1' }
-  its(:gce_zone)         { should eq 'us-central1-a' }
+describe command("gcloud --project='#{project_id}' sql instances describe #{basename} --format=json") do
+  its(:exit_status) { should eq 0 }
+  its(:stderr) { should eq '' }
 
-  it { expect(settings).to include(expected_settings) }
-  it { expect(ip_configuration).to include(authorized_networks: [{kind: 'sql#aclEntry', name: "#{project_id}-cidr", value: authorized_network}], ipv4_enabled: true, require_ssl: true) }
-  it { expect(location_preference).to include(kind: "sql#locationPreference", zone: "us-central1-a") }
-  it { expect(maintenance_window).to include(kind: "sql#maintenanceWindow", day: 7, hour: 12, update_track: "stable") }
-  it { expect(user_labels).to include(foo: "bar") }
+  let!(:data) do
+    if subject.exit_status == 0
+      JSON.parse(subject.stdout)
+    else
+      {}
+    end
+  end
+
+  describe "mssql_ha_database" do
+    it "global settings are valid" do
+      expect(data['settings']['activationPolicy']).to eq "#{activation_policy}"
+      expect(data['settings']['availabilityType']).to eq "#{availability_type}"
+      expect(data['settings']['dataDiskSizeGb']).to eq "#{data_disk_size_gb}"
+      expect(data['settings']['dataDiskType']).to eq "#{data_disk_type}"
+      expect(data['settings']['kind']).to eq "#{kind}"
+      expect(data['settings']['pricingPlan']).to eq "#{pricing_plan}"
+      expect(data['settings']['replicationType']).to eq "#{replication_type}"
+      expect(data['settings']['storageAutoResize']).to eq storage_auto_resize
+      expect(data['settings']['storageAutoResizeLimit']).to eq "#{storage_auto_resize_limit}"
+      expect(data['settings']['tier']).to eq "#{tier}"
+    end
+
+    it "backend type is valid" do
+      expect(data['backendType']).to eq 'SECOND_GEN'
+    end
+
+    it "database versions is valid" do
+      expect(data['databaseVersion']).to eq 'SQLSERVER_2017_STANDARD'
+    end
+
+    it "state is valid" do
+      expect(data['state']).to eq 'RUNNABLE'
+    end
+
+    it "region is valid" do
+      expect(data['region']).to eq region
+    end
+
+    it "gce zone is valid" do
+      expect(data['gceZone']).to eq "#{region}-a"
+    end
+
+    it "location preference is valid" do
+      expect(data['settings']['locationPreference']).to include(
+        "kind" => "sql#locationPreference",
+        "zone" => "#{region}-a")
+    end
+
+    it "maintenance window is valid" do
+      expect(data['settings']['maintenanceWindow']).to include(
+      "kind" => "sql#maintenanceWindow",
+      "day" => 7,
+      "hour" => 12,
+      "updateTrack" => "stable")
+    end
+
+    it "ip configuration and authorized networks are valid" do
+      expect(data['settings']['ipConfiguration']).to include(
+        ["authorizedNetworks"][0] => [{
+          "kind" => "sql#aclEntry",
+          "name" => "#{project_id}-cidr",
+          "value" => authorized_network
+        }],
+        "ipv4Enabled" => true,
+        "requireSsl" => true,
+      )
+    end
+
+    it "user labels are set" do
+      expect(data['settings']['userLabels']).to include(
+        "foo" => "bar")
+    end
+  end
 end
 
-describe google_sql_users(project: project_id, database: basename).where(user_name: /\Atftest/) do
-  its(:count) { should be 3 }
-  it { should exist }
+describe command("gcloud --project='#{project_id}' sql users list --instance #{basename} --format=json") do
+  its(:exit_status) { should eq 0 }
+  its(:stderr) { should eq '' }
+
+  let!(:data) do
+    if subject.exit_status == 0
+      JSON.parse(subject.stdout)
+    else
+      {}
+    end
+  end
+
+  describe "mssql_ha_database" do
+    it "has 3 users" do
+      expect(data.select {|k,v| k['name'].start_with?("tftest")}.size).to eq 3
+    end
+  end
 end

--- a/test/integration/mssql-ha/inspec.yml
+++ b/test/integration/mssql-ha/inspec.yml
@@ -15,9 +15,6 @@
 name: cloud-sql
 title: Google Cloud SQL
 version: 0.1.0
-depends:
-  - name: inspec-gcp
-    url: https://github.com/inspec/inspec-gcp/archive/v0.21.4.tar.gz
 attributes:
   - name: project_id
     type: string

--- a/test/integration/mssql-public/controls/mssql.rb
+++ b/test/integration/mssql-public/controls/mssql.rb
@@ -12,33 +12,79 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'json'
+
 project_id = attribute('project_id')
 basename   = attribute('name')
+region = "us-central1"
 
-describe google_sql_database_instance(project: project_id, database: basename) do
-  let(:expected_settings) {
-    {
-      activation_policy: "ALWAYS",
-      data_disk_size_gb: 10,
-      data_disk_type: "PD_SSD",
-      kind: "sql#settings",
-      pricing_plan: "PER_USE",
-      replication_type: "SYNCHRONOUS",
-      storage_auto_resize: true,
-      storage_auto_resize_limit: 0,
-      tier: "db-custom-2-3840",
-    }
-  }
-  let(:settings)                { subject.settings.item }
-  let(:location_preference)     { settings[:location_preference] }
-  let(:maintenance_window)      { settings[:maintenance_window] }
+activation_policy = "ALWAYS"
+data_disk_size_gb = 10
+data_disk_type = "PD_SSD"
+kind = "sql#settings"
+pricing_plan = "PER_USE"
+replication_type = "SYNCHRONOUS"
+storage_auto_resize = true
+storage_auto_resize_limit = 0
+tier = "db-custom-2-3840"
 
-  its(:backend_type)     { should eq 'SECOND_GEN' }
-  its(:database_version) { should eq 'SQLSERVER_2017_STANDARD' }
-  its(:state)            { should eq 'RUNNABLE' }
-  its(:region)           { should eq 'us-central1' }
-  its(:gce_zone)         { should eq 'us-central1-a' }
-  it { expect(settings).to include(expected_settings) }
-  it { expect(location_preference).to include(kind: "sql#locationPreference", zone: "us-central1-a") }
-  it { expect(maintenance_window).to include(kind: "sql#maintenanceWindow", day: 1, hour: 23, update_track: "canary") }
+describe command("gcloud --project='#{project_id}' sql instances describe #{basename} --format=json") do
+  its(:exit_status) { should eq 0 }
+  its(:stderr) { should eq '' }
+
+  let!(:data) do
+    if subject.exit_status == 0
+      JSON.parse(subject.stdout)
+    else
+      {}
+    end
+  end
+
+  describe "mssql_public_database" do
+    it "global settings are valid" do
+      expect(data['settings']['activationPolicy']).to eq "#{activation_policy}"
+      expect(data['settings']['dataDiskSizeGb']).to eq "#{data_disk_size_gb}"
+      expect(data['settings']['dataDiskType']).to eq "#{data_disk_type}"
+      expect(data['settings']['kind']).to eq "#{kind}"
+      expect(data['settings']['pricingPlan']).to eq "#{pricing_plan}"
+      expect(data['settings']['replicationType']).to eq "#{replication_type}"
+      expect(data['settings']['storageAutoResize']).to eq storage_auto_resize
+      expect(data['settings']['storageAutoResizeLimit']).to eq "#{storage_auto_resize_limit}"
+      expect(data['settings']['tier']).to eq "#{tier}"
+    end
+
+    it "backend type is valid" do
+      expect(data['backendType']).to eq 'SECOND_GEN'
+    end
+
+    it "database versions is valid" do
+      expect(data['databaseVersion']).to eq 'SQLSERVER_2017_STANDARD'
+    end
+
+    it "state is valid" do
+      expect(data['state']).to eq 'RUNNABLE'
+    end
+
+    it "region is valid" do
+      expect(data['region']).to eq region
+    end
+
+    it "gce zone is valid" do
+      expect(data['gceZone']).to eq "#{region}-a"
+    end
+
+    it "location preference is valid" do
+      expect(data['settings']['locationPreference']).to include(
+        "kind" => "sql#locationPreference",
+        "zone" => "#{region}-a")
+    end
+
+    it "maintenance window is valid" do
+      expect(data['settings']['maintenanceWindow']).to include(
+      "kind" => "sql#maintenanceWindow",
+      "day" => 1,
+      "hour" => 23,
+      "updateTrack" => "canary")
+    end
+  end
 end

--- a/test/integration/mssql-public/inspec.yml
+++ b/test/integration/mssql-public/inspec.yml
@@ -15,9 +15,6 @@
 name: cloud-sql
 title: Google Cloud SQL
 version: 0.1.0
-depends:
-  - name: inspec-gcp
-    url: https://github.com/inspec/inspec-gcp/archive/v0.21.4.tar.gz
 attributes:
   - name: project_id
     type: string

--- a/test/integration/mysql-ha/controls/mysql.rb
+++ b/test/integration/mysql-ha/controls/mysql.rb
@@ -12,99 +12,239 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'json'
+
 project_id = attribute('project_id')
 basename   = attribute('name')
 authorized_network = attribute('authorized_network')
 replicas = attribute('replicas')
 instances = attribute('instances')
+mysql_version = "MYSQL_5_7"
+region = "us-central1"
 
-describe google_sql_database_instances(project: project_id).where(instance_name: /#{basename}/) do
-  its(:count) { should eq 4 }
-  its(:count) { should eq 1 + replicas.length }
-  its(:count) { should eq instances.length }
-end
+activation_policy = "ALWAYS"
+availability_type = "REGIONAL"
+availability_type_replica = "ZONAL"
+data_disk_size_gb = 10
+data_disk_type = "PD_SSD"
+data_disk_type_replica = "PD_HDD"
+kind = "sql#settings"
+pricing_plan = "PER_USE"
+replication_type = "SYNCHRONOUS"
+storage_auto_resize = true
+storage_auto_resize_limit = 0
+tier = "db-n1-standard-1"
 
-describe google_sql_database_instance(project: project_id, database: basename) do
-  let(:expected_settings) {
-    {
-      activation_policy: "ALWAYS",
-      availability_type: "REGIONAL",
-      data_disk_size_gb: 10,
-      data_disk_type: "PD_SSD",
-      kind: "sql#settings",
-      pricing_plan: "PER_USE",
-      replication_type: "SYNCHRONOUS",
-      storage_auto_resize: true,
-      storage_auto_resize_limit: 0,
-      tier: "db-n1-standard-1",
-    }
-  }
-  let(:settings)                { subject.settings.item }
-  let(:backup_configuration)    { settings[:backup_configuration] }
-  let(:ip_configuration)        { settings[:ip_configuration] }
-  let(:database_flags)          { settings[:database_flags] }
-  let(:location_preference)     { settings[:location_preference] }
-  let(:maintenance_window)      { settings[:maintenance_window] }
-  let(:user_labels)             { settings[:user_labels] }
+describe command("gcloud --project='#{project_id}' sql instances list --filter='name ~ ^#{basename}' --format=json") do
+  let!(:data) do
+    if subject.exit_status == 0
+      JSON.parse(subject.stdout)
+    else
+      {}
+    end
+  end
 
-  its(:backend_type)     { should eq 'SECOND_GEN' }
-  its(:database_version) { should eq 'MYSQL_5_7' }
-  its(:state)            { should eq 'RUNNABLE' }
-  its(:region)           { should eq 'us-central1' }
-  its(:gce_zone)         { should eq 'us-central1-c' }
-
-  it { expect(settings).to include(expected_settings) }
-  it { expect(backup_configuration).to include(binary_log_enabled: true, enabled: true, kind: "sql#backupConfiguration", start_time: "20:55") }
-  it { expect(ip_configuration).to include(authorized_networks: [{kind: 'sql#aclEntry', name: "#{project_id}-cidr", value: authorized_network}], ipv4_enabled: true, require_ssl: true) }
-  it { expect(database_flags).to include(name: "long_query_time", value: "1") }
-  it { expect(location_preference).to include(kind: "sql#locationPreference", zone: "us-central1-c") }
-  it { expect(maintenance_window).to include(kind: "sql#maintenanceWindow", day: 7, hour: 12, update_track: "stable") }
-  it { expect(user_labels).to include(foo: "bar") }
-end
-
-%i[a b c].each_with_index do |zone, index|
-  name = "#{basename}-replica-test#{index}"
-  describe google_sql_database_instance(project: project_id, database: name) do
-    its(:name) { should eq replicas[index]['name'] }
-
-    let(:expected_settings) {
-      {
-        activation_policy: "ALWAYS",
-        data_disk_size_gb: 10,
-        data_disk_type: "PD_HDD",
-        kind: "sql#settings",
-        pricing_plan: "PER_USE",
-        replication_type: "SYNCHRONOUS",
-        storage_auto_resize: true,
-        storage_auto_resize_limit: 0,
-        tier: "db-n1-standard-1",
-      }
-    }
-    let(:settings)                { subject.settings.item }
-    let(:ip_configuration)        { settings[:ip_configuration] }
-    let(:database_flags)          { settings[:database_flags] }
-    let(:location_preference)     { settings[:location_preference] }
-    let(:user_labels)             { settings[:user_labels] }
-
-    its(:backend_type)     { should eq 'SECOND_GEN' }
-    its(:database_version) { should eq 'MYSQL_5_7' }
-    its(:state)            { should eq 'RUNNABLE' }
-    its(:region)           { should eq 'us-central1' }
-    its(:gce_zone)         { should eq "us-central1-#{zone}" }
-
-    it { expect(settings).to include(expected_settings) }
-    it { expect(ip_configuration).to include(authorized_networks: [{kind: 'sql#aclEntry', name: "#{project_id}-cidr", value: authorized_network}], ipv4_enabled: true, require_ssl: false) }
-    it { expect(database_flags).to include(name: "long_query_time", value: "1") }
-    it { expect(location_preference).to include(kind: "sql#locationPreference", zone: "us-central1-#{zone}") }
-    it { expect(user_labels).to include(bar: "baz") }
+  describe "mysql_ha_database" do
+    it "has 1 primary instance and 3 replicas" do
+      expect(data.size).to eq 4
+    end
   end
 end
 
-describe google_sql_users(project: project_id, database: basename).where(user_name: /\Atftest/) do
-  its(:count) { should be 3 }
-  it { should exist }
+describe command("gcloud --project='#{project_id}' sql instances describe #{basename} --format=json") do
+  its(:exit_status) { should eq 0 }
+  its(:stderr) { should eq '' }
+
+  let!(:data) do
+    if subject.exit_status == 0
+      JSON.parse(subject.stdout)
+    else
+      {}
+    end
+  end
+
+  describe "mysql_ha_database" do
+    it "global settings are valid" do
+      expect(data['settings']['activationPolicy']).to eq "#{activation_policy}"
+      expect(data['settings']['availabilityType']).to eq "#{availability_type}"
+      expect(data['settings']['dataDiskSizeGb']).to eq "#{data_disk_size_gb}"
+      expect(data['settings']['dataDiskType']).to eq "#{data_disk_type}"
+      expect(data['settings']['kind']).to eq "#{kind}"
+      expect(data['settings']['pricingPlan']).to eq "#{pricing_plan}"
+      expect(data['settings']['replicationType']).to eq "#{replication_type}"
+      expect(data['settings']['storageAutoResize']).to eq storage_auto_resize
+      expect(data['settings']['storageAutoResizeLimit']).to eq "#{storage_auto_resize_limit}"
+      expect(data['settings']['tier']).to eq "#{tier}"
+    end
+
+    it "backend type is valid" do
+      expect(data['backendType']).to eq 'SECOND_GEN'
+    end
+
+    it "database versions is valid" do
+      expect(data['databaseVersion']).to eq mysql_version
+    end
+
+    it "state is valid" do
+      expect(data['state']).to eq 'RUNNABLE'
+    end
+
+    it "region is valid" do
+      expect(data['region']).to eq region
+    end
+
+    it "gce zone is valid" do
+      expect(data['gceZone']).to eq "#{region}-c"
+    end
+
+    it "location preference is valid" do
+      expect(data['settings']['locationPreference']).to include(
+      "kind" => "sql#locationPreference",
+      "zone" => "#{region}-c")
+    end
+
+    it "maintenance window is valid" do
+      expect(data['settings']['maintenanceWindow']).to include(
+      "kind" => "sql#maintenanceWindow",
+      "day" => 7,
+      "hour" => 12,
+      "updateTrack" => "stable")
+    end
+
+    it "ip configuration and authorized networks are valid" do
+      expect(data['settings']['ipConfiguration']).to include(
+        ["authorizedNetworks"][0] => [{
+          "kind" => "sql#aclEntry",
+          "name" => "#{project_id}-cidr",
+          "value" => authorized_network
+        }],
+        "ipv4Enabled" => true,
+        "requireSsl" => true,
+      )
+    end
+
+    it "user labels are set" do
+      expect(data['settings']['userLabels']).to include(
+        "foo" => "bar")
+    end
+
+    it "database flags are set" do
+      expect(data['settings']['databaseFlags']).to include({
+        "name" => "long_query_time",
+        "value" => "1"})
+    end
+
+    it "backup configuration is enabled" do
+      expect(data['settings']['backupConfiguration']).to include(
+        "binaryLogEnabled" => true,
+        "enabled" => true,
+        "kind" => "sql#backupConfiguration",
+        "startTime" => "20:55")
+    end
+
+  end
 end
 
-describe google_sql_users(project: project_id, database: basename).where(user_host: 'localhost') do
-  it { should exist }
+%i[a b c].each_with_index do |zone, index|
+  replica_name = "#{basename}-replica-test#{index}"
+
+  describe command("gcloud --project='#{project_id}' sql instances describe #{replica_name} --format=json") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq '' }
+
+    let!(:data) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout)
+      else
+        {}
+      end
+    end
+
+    describe "mysql_ha_database" do
+      it "global settings are valid" do
+        expect(data['settings']['activationPolicy']).to eq "#{activation_policy}"
+        expect(data['settings']['availabilityType']).to eq "#{availability_type_replica}"
+        expect(data['settings']['dataDiskSizeGb']).to eq "#{data_disk_size_gb}"
+        expect(data['settings']['dataDiskType']).to eq "#{data_disk_type_replica}"
+        expect(data['settings']['kind']).to eq "#{kind}"
+        expect(data['settings']['pricingPlan']).to eq "#{pricing_plan}"
+        expect(data['settings']['replicationType']).to eq "#{replication_type}"
+        expect(data['settings']['storageAutoResize']).to eq storage_auto_resize
+        expect(data['settings']['storageAutoResizeLimit']).to eq "#{storage_auto_resize_limit}"
+        expect(data['settings']['tier']).to eq "#{tier}"
+      end
+
+      it "backend type is valid" do
+        expect(data['backendType']).to eq 'SECOND_GEN'
+      end
+
+      it "database versions is valid" do
+        expect(data['databaseVersion']).to eq mysql_version
+      end
+
+      it "state is valid" do
+        expect(data['state']).to eq 'RUNNABLE'
+      end
+
+      it "region is valid" do
+        expect(data['region']).to eq region
+      end
+
+      it "gce zone is valid" do
+        expect(data['gceZone']).to eq "#{region}-#{zone}"
+      end
+
+      it "location preference is valid" do
+        expect(data['settings']['locationPreference']).to include(
+        "kind" => "sql#locationPreference",
+        "zone" => "#{region}-#{zone}")
+      end
+
+      it "ip configuration and authorized networks are valid" do
+        expect(data['settings']['ipConfiguration']).to include(
+          ["authorizedNetworks"][0] => [{
+            "kind" => "sql#aclEntry",
+            "name" => "#{project_id}-cidr",
+            "value" => authorized_network
+          }],
+          "ipv4Enabled" => true,
+          "requireSsl" => false,
+        )
+      end
+
+      it "user labels are set" do
+        expect(data['settings']['userLabels']).to include(
+          "bar" => "baz")
+      end
+
+      it "database flags are set" do
+        expect(data['settings']['databaseFlags']).to include({
+          "name" => "long_query_time",
+          "value" => "1"})
+      end
+    end
+  end
+end
+
+describe command("gcloud --project='#{project_id}' sql users list --instance #{basename} --format=json") do
+  its(:exit_status) { should eq 0 }
+  its(:stderr) { should eq '' }
+
+  let!(:data) do
+    if subject.exit_status == 0
+      JSON.parse(subject.stdout)
+    else
+      {}
+    end
+  end
+
+  describe "mysql_ha_database" do
+    it "has 3 users" do
+      expect(data.select {|k,v| k['name'].start_with?("tftest")}.size).to eq 3
+    end
+
+    it "is setup for localhost" do
+      expect(data.select {|k,v| k['host'] == "localhost"}.size).to be >= 1
+    end
+  end
 end

--- a/test/integration/mysql-ha/inspec.yml
+++ b/test/integration/mysql-ha/inspec.yml
@@ -15,9 +15,6 @@
 name: cloud-sql
 title: Google Cloud SQL
 version: 0.1.0
-depends:
-  - name: inspec-gcp
-    url: https://github.com/inspec/inspec-gcp/archive/v0.21.4.tar.gz
 attributes:
   - name: project_id
     type: string

--- a/test/integration/mysql-private/controls/mysql.rb
+++ b/test/integration/mysql-private/controls/mysql.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'json'
+
 project_id = attribute('project_id')
 basename   = attribute('name')
 public_ip_address = attribute('public_ip_address')
@@ -20,56 +22,94 @@ mysql_version = "MYSQL_5_6"
 region = "us-central1"
 tier = "db-n1-standard-1"
 
+activation_policy = "ALWAYS"
+data_disk_size_gb = 10
+data_disk_type = "PD_SSD"
+kind = "sql#settings"
+pricing_plan = "PER_USE"
+replication_type = "SYNCHRONOUS"
+storage_auto_resize = true
+storage_auto_resize_limit = 0
 
-describe google_sql_database_instance(project: project_id, database: basename) do
-  let(:expected_settings) {
-    {
-      activation_policy: "ALWAYS",
-      data_disk_size_gb: 10,
-      data_disk_type: "PD_SSD",
-      kind: "sql#settings",
-      pricing_plan: "PER_USE",
-      replication_type: "SYNCHRONOUS",
-      storage_auto_resize: true,
-      storage_auto_resize_limit: 0,
-      tier: tier,
-    }
-  }
+describe command("gcloud --project='#{project_id}' sql instances describe #{basename} --format=json") do
+  its(:exit_status) { should eq 0 }
+  its(:stderr) { should eq '' }
 
-  let(:settings)                { subject.settings.item }
-  let(:instance_ip_addresses)   { subject.ip_addresses }
-  let(:location_preference)     { settings[:location_preference] }
-  let(:maintenance_window)      { settings[:maintenance_window] }
+  let!(:data) do
+    if subject.exit_status == 0
+      JSON.parse(subject.stdout)
+    else
+      {}
+    end
+  end
 
-  its(:backend_type)     { should eq 'SECOND_GEN' }
-  its(:database_version) { should eq mysql_version }
-  its(:state)            { should eq 'RUNNABLE' }
-  its(:region)           { should eq region }
-  its(:gce_zone)         { should eq "#{region}-c" }
+  describe "mysql_private_database" do
+    it "global settings are valid" do
+      expect(data['settings']['activationPolicy']).to eq "#{activation_policy}"
+      expect(data['settings']['dataDiskSizeGb']).to eq "#{data_disk_size_gb}"
+      expect(data['settings']['dataDiskType']).to eq "#{data_disk_type}"
+      expect(data['settings']['kind']).to eq "#{kind}"
+      expect(data['settings']['pricingPlan']).to eq "#{pricing_plan}"
+      expect(data['settings']['replicationType']).to eq "#{replication_type}"
+      expect(data['settings']['storageAutoResize']).to eq storage_auto_resize
+      expect(data['settings']['storageAutoResizeLimit']).to eq "#{storage_auto_resize_limit}"
+      expect(data['settings']['tier']).to eq "#{tier}"
+    end
 
-  it { expect(settings).to include(expected_settings) }
-  it { expect(location_preference).to include(kind: "sql#locationPreference", zone: "#{region}-c") }
-  it { expect(maintenance_window).to include(kind: "sql#maintenanceWindow", day: 1, hour: 23, update_track: "stable") }
+    it "backend type is valid" do
+      expect(data['backendType']).to eq 'SECOND_GEN'
+    end
+
+    it "database versions is valid" do
+      expect(data['databaseVersion']).to eq mysql_version
+    end
+
+    it "state is valid" do
+      expect(data['state']).to eq 'RUNNABLE'
+    end
+
+    it "region is valid" do
+      expect(data['region']).to eq region
+    end
+
+    it "gce zone is valid" do
+      expect(data['gceZone']).to eq "#{region}-c"
+    end
+
+    it "location preference is valid" do
+      expect(data['settings']['locationPreference']).to include(
+      "kind" => "sql#locationPreference",
+      "zone" => "#{region}-c")
+    end
+
+    it "maintenance window is valid" do
+      expect(data['settings']['maintenanceWindow']).to include(
+      "kind" => "sql#maintenanceWindow",
+      "day" => 1,
+      "hour" => 23,
+      "updateTrack" => "stable")
+    end
+  end
 
   describe "MySQL private instance" do
     it "has two assigned IP addresses" do
-      expect(instance_ip_addresses.count).to eq(2)
+      expect(data["ipAddresses"].count).to eq(2)
     end
 
     it "has expected external IP address" do
-      expect(instance_ip_addresses[0].item).to eq(
+      expect(data["ipAddresses"][0]).to eq(
         {
-          type: "PRIMARY",
-          ip_address: "#{public_ip_address}"
+          "type" => "PRIMARY",
+          "ipAddress" => "#{public_ip_address}"
         }
       )
     end
 
     it "has expected internal IP address" do
-      expect(instance_ip_addresses[1].item).to eq(
+      expect(data["ipAddresses"][1]).to eq(
         {
-          type: "PRIVATE",
-          ip_address: "#{private_ip_address}"
+          "type" => "PRIVATE",
+          "ipAddress" => "#{private_ip_address}"
         }
       )
     end

--- a/test/integration/mysql-private/controls/peering.rb
+++ b/test/integration/mysql-private/controls/peering.rb
@@ -15,7 +15,21 @@
 project_id = attribute('project_id')
 range      = attribute('reserved_range_name')
 
-describe google_compute_global_address(project: project_id, name: range) do
-    it { should exist }
-    # Verify that address_type eq INTERNAL, once inspec supports it.
+describe command("gcloud --project='#{project_id}' compute addresses list --global --filter='#{range}' --format=json") do
+  its(:exit_status) { should eq 0 }
+  its(:stderr) { should eq '' }
+
+  let!(:data) do
+    if subject.exit_status == 0
+      JSON.parse(subject.stdout)
+    else
+      {}
+    end
   end
+
+  describe "mysql_private_database" do
+    it "has peering setup" do
+      expect(data.size).to eq(1)
+    end
+  end
+end

--- a/test/integration/mysql-private/inspec.yml
+++ b/test/integration/mysql-private/inspec.yml
@@ -15,9 +15,6 @@
 name: cloud-sql
 title: Google Cloud SQL
 version: 0.1.0
-depends:
-  - name: inspec-gcp
-    url: https://github.com/inspec/inspec-gcp/archive/v0.21.4.tar.gz
 attributes:
   - name: project_id
     type: string

--- a/test/integration/mysql-public/controls/mysql.rb
+++ b/test/integration/mysql-public/controls/mysql.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'json'
+
 project_id = attribute('project_id')
 basename   = attribute('name')
 public_ip_address = attribute('public_ip_address')
@@ -20,45 +22,85 @@ mysql_version = "MYSQL_5_6"
 region = "us-central1"
 tier = "db-n1-standard-1"
 
-describe google_sql_database_instance(project: project_id, database: basename) do
-  let(:expected_settings) {
-    {
-      activation_policy: "ALWAYS",
-      data_disk_size_gb: 10,
-      data_disk_type: "PD_SSD",
-      kind: "sql#settings",
-      pricing_plan: "PER_USE",
-      replication_type: "SYNCHRONOUS",
-      storage_auto_resize: true,
-      storage_auto_resize_limit: 0,
-      tier: tier,
-    }
-  }
-  let(:settings)                { subject.settings.item }
-  let(:location_preference)     { settings[:location_preference] }
-  let(:maintenance_window)      { settings[:maintenance_window] }
-  let(:instance_ip_addresses)   { subject.ip_addresses }
+activation_policy = "ALWAYS"
+data_disk_size_gb = 10
+data_disk_type = "PD_SSD"
+kind = "sql#settings"
+pricing_plan = "PER_USE"
+replication_type = "SYNCHRONOUS"
+storage_auto_resize = true
+storage_auto_resize_limit = 0
 
-  its(:backend_type)     { should eq 'SECOND_GEN' }
-  its(:database_version) { should eq mysql_version }
-  its(:state)            { should eq 'RUNNABLE' }
-  its(:region)           { should eq region }
-  its(:gce_zone)         { should eq "#{region}-c" }
+describe command("gcloud --project='#{project_id}' sql instances describe #{basename} --format=json") do
+  its(:exit_status) { should eq 0 }
+  its(:stderr) { should eq '' }
 
-  it { expect(settings).to include(expected_settings) }
-  it { expect(location_preference).to include(kind: "sql#locationPreference", zone: "#{region}-c") }
-  it { expect(maintenance_window).to include(kind: "sql#maintenanceWindow", day: 1, hour: 23, update_track: "canary") }
+  let!(:data) do
+    if subject.exit_status == 0
+      JSON.parse(subject.stdout)
+    else
+      {}
+    end
+  end
 
-describe "MySQL pubic instance" do
+  describe "mysql_database" do
+    it "global settings are valid" do
+      expect(data['settings']['activationPolicy']).to eq "#{activation_policy}"
+      expect(data['settings']['dataDiskSizeGb']).to eq "#{data_disk_size_gb}"
+      expect(data['settings']['dataDiskType']).to eq "#{data_disk_type}"
+      expect(data['settings']['kind']).to eq "#{kind}"
+      expect(data['settings']['pricingPlan']).to eq "#{pricing_plan}"
+      expect(data['settings']['replicationType']).to eq "#{replication_type}"
+      expect(data['settings']['storageAutoResize']).to eq storage_auto_resize
+      expect(data['settings']['storageAutoResizeLimit']).to eq "#{storage_auto_resize_limit}"
+      expect(data['settings']['tier']).to eq "#{tier}"
+    end
+
+    it "backend type is valid" do
+      expect(data['backendType']).to eq 'SECOND_GEN'
+    end
+
+    it "database versions is valid" do
+      expect(data['databaseVersion']).to eq mysql_version
+    end
+
+    it "state is valid" do
+      expect(data['state']).to eq 'RUNNABLE'
+    end
+
+    it "region is valid" do
+      expect(data['region']).to eq region
+    end
+
+    it "gce zone is valid" do
+      expect(data['gceZone']).to eq "#{region}-c"
+    end
+
+    it "location preference is valid" do
+      expect(data['settings']['locationPreference']).to include(
+      "kind" => "sql#locationPreference",
+      "zone" => "#{region}-c")
+    end
+
+    it "maintenance window is valid" do
+      expect(data['settings']['maintenanceWindow']).to include(
+      "kind" => "sql#maintenanceWindow",
+      "day" => 1,
+      "hour" => 23,
+      "updateTrack" => "canary")
+    end
+  end
+
+  describe "MySQL public instance" do
     it "has just one assigned IP address" do
-      expect(instance_ip_addresses.count).to eq(1)
+      expect(data["ipAddresses"].count).to eq(1)
     end
 
     it "has expected external IP address" do
-      expect(instance_ip_addresses[0].item).to eq(
+      expect(data["ipAddresses"][0]).to eq(
         {
-          type: "PRIMARY",
-          ip_address: "#{public_ip_address}"
+          "type" => "PRIMARY",
+          "ipAddress" => "#{public_ip_address}"
         }
       )
     end

--- a/test/integration/mysql-public/inspec.yml
+++ b/test/integration/mysql-public/inspec.yml
@@ -15,9 +15,6 @@
 name: cloud-sql
 title: Google Cloud SQL
 version: 0.1.0
-depends:
-  - name: inspec-gcp
-    url: https://github.com/inspec/inspec-gcp/archive/v0.21.4.tar.gz
 attributes:
   - name: project_id
     type: string

--- a/test/integration/postgresql-ha/inspec.yml
+++ b/test/integration/postgresql-ha/inspec.yml
@@ -15,9 +15,6 @@
 name: cloud-sql
 title: Google Cloud SQL
 version: 0.1.0
-depends:
-  - name: inspec-gcp
-    url: https://github.com/inspec/inspec-gcp/archive/v0.21.4.tar.gz
 attributes:
   - name: project_id
     type: string

--- a/test/integration/postgresql-public-iam/controls/pg.rb
+++ b/test/integration/postgresql-public-iam/controls/pg.rb
@@ -1,0 +1,136 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = attribute('project_id')
+basename   = attribute('name')
+db_version = "POSTGRES_9_6"
+region = "us-central1"
+tier = "db-f1-micro"
+public_ip_address = attribute('public_ip_address')
+
+activation_policy = "ALWAYS"
+data_disk_size_gb = 10
+data_disk_type = "PD_SSD"
+kind = "sql#settings"
+pricing_plan = "PER_USE"
+replication_type = "SYNCHRONOUS"
+storage_auto_resize = true
+storage_auto_resize_limit = 0
+
+describe command("gcloud --project='#{project_id}' sql instances describe #{basename} --format=json") do
+  its(:exit_status) { should eq 0 }
+  its(:stderr) { should eq '' }
+
+  let!(:data) do
+    if subject.exit_status == 0
+      JSON.parse(subject.stdout)
+    else
+      {}
+    end
+  end
+
+  describe "postgresql_public_database" do
+    it "global settings are valid" do
+      expect(data['settings']['activationPolicy']).to eq "#{activation_policy}"
+      expect(data['settings']['dataDiskSizeGb']).to eq "#{data_disk_size_gb}"
+      expect(data['settings']['dataDiskType']).to eq "#{data_disk_type}"
+      expect(data['settings']['kind']).to eq "#{kind}"
+      expect(data['settings']['pricingPlan']).to eq "#{pricing_plan}"
+      expect(data['settings']['replicationType']).to eq "#{replication_type}"
+      expect(data['settings']['storageAutoResize']).to eq storage_auto_resize
+      expect(data['settings']['storageAutoResizeLimit']).to eq "#{storage_auto_resize_limit}"
+      expect(data['settings']['tier']).to eq "#{tier}"
+    end
+
+    it "backend type is valid" do
+      expect(data['backendType']).to eq 'SECOND_GEN'
+    end
+
+    it "database versions is valid" do
+      expect(data['databaseVersion']).to eq db_version
+    end
+
+    it "state is valid" do
+      expect(data['state']).to eq 'RUNNABLE'
+    end
+
+    it "region is valid" do
+      expect(data['region']).to eq region
+    end
+
+    it "gce zone is valid" do
+      expect(data['gceZone']).to eq "#{region}-c"
+    end
+
+    it "location preference is valid" do
+      expect(data['settings']['locationPreference']).to include(
+      "kind" => "sql#locationPreference",
+      "zone" => "#{region}-c")
+    end
+
+    it "maintenance window is valid" do
+      expect(data['settings']['maintenanceWindow']).to include(
+      "kind" => "sql#maintenanceWindow",
+      "day" => 1,
+      "hour" => 23,
+      "updateTrack" => "canary")
+    end
+
+    it "database flags are set" do
+      expect(data['settings']['databaseFlags']).to include({
+        "name" => "cloudsql.iam_authentication",
+        "value" => "on"})
+    end
+  end
+
+  describe "Postgres SQL pubic instance" do
+    it "has just one assigned IP address" do
+      expect(data["ipAddresses"].count).to eq(1)
+    end
+
+    it "has expected external IP address" do
+      expect(data["ipAddresses"][0]).to eq(
+        {
+          "type" => "PRIMARY",
+          "ipAddress" => "#{public_ip_address}"
+        }
+      )
+    end
+  end
+end
+
+describe command("gcloud --project='#{project_id}' sql users list --instance #{basename} --format=json") do
+  its(:exit_status) { should eq 0 }
+  its(:stderr) { should eq '' }
+
+  let!(:data) do
+    if subject.exit_status == 0
+      JSON.parse(subject.stdout)
+    else
+      {}
+    end
+  end
+
+  describe "postgresql_public_database" do
+    it "has 1 IAM user" do
+      expect(data.select {|k,v| k['type'] == "CLOUD_IAM_USER"}.size).to eq 1
+    end
+  end
+
+  describe "postgresql_public_database" do
+    it "has 1 IAM service account user" do
+      expect(data.select {|k,v| k['type'] == "CLOUD_IAM_SERVICE_ACCOUNT"}.size).to eq 1
+    end
+  end
+end

--- a/test/integration/postgresql-public-iam/inspec.yml
+++ b/test/integration/postgresql-public-iam/inspec.yml
@@ -1,0 +1,28 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: cloud-sql
+title: Google Cloud SQL
+version: 0.1.0
+attributes:
+  - name: project_id
+    type: string
+    required: true
+  - name: name
+    type: string
+    required: true
+  - name: public_ip_address
+    type: string
+    required: true
+

--- a/test/integration/postgresql-public/controls/pg.rb
+++ b/test/integration/postgresql-public/controls/pg.rb
@@ -19,47 +19,87 @@ region = "us-central1"
 tier = "db-f1-micro"
 public_ip_address = attribute('public_ip_address')
 
-describe google_sql_database_instance(project: project_id, database: basename) do
-  let(:expected_settings) {
-    {
-      activation_policy: "ALWAYS",
-      data_disk_size_gb: 10,
-      data_disk_type: "PD_SSD",
-      kind: "sql#settings",
-      pricing_plan: "PER_USE",
-      replication_type: "SYNCHRONOUS",
-      storage_auto_resize: true,
-      storage_auto_resize_limit: 0,
-      tier: tier,
-    }
-  }
-  let(:settings)                { subject.settings.item }
-  let(:location_preference)     { settings[:location_preference] }
-  let(:maintenance_window)      { settings[:maintenance_window] }
-  let(:instance_ip_addresses)   { subject.ip_addresses }
+activation_policy = "ALWAYS"
+data_disk_size_gb = 10
+data_disk_type = "PD_SSD"
+kind = "sql#settings"
+pricing_plan = "PER_USE"
+replication_type = "SYNCHRONOUS"
+storage_auto_resize = true
+storage_auto_resize_limit = 0
 
-  its(:backend_type)     { should eq 'SECOND_GEN' }
-  its(:database_version) { should eq db_version }
-  its(:state)            { should eq 'RUNNABLE' }
-  its(:region)           { should eq region }
-  its(:gce_zone)         { should eq "#{region}-c" }
-  it { expect(settings).to include(expected_settings) }
-  it { expect(location_preference).to include(kind: "sql#locationPreference", zone: "#{region}-c") }
-  it { expect(maintenance_window).to include(kind: "sql#maintenanceWindow", day: 1, hour: 23, update_track: "canary") }
+describe command("gcloud --project='#{project_id}' sql instances describe #{basename} --format=json") do
+  its(:exit_status) { should eq 0 }
+  its(:stderr) { should eq '' }
+
+  let!(:data) do
+    if subject.exit_status == 0
+      JSON.parse(subject.stdout)
+    else
+      {}
+    end
+  end
+
+  describe "postgresql_public_database" do
+    it "global settings are valid" do
+      expect(data['settings']['activationPolicy']).to eq "#{activation_policy}"
+      expect(data['settings']['dataDiskSizeGb']).to eq "#{data_disk_size_gb}"
+      expect(data['settings']['dataDiskType']).to eq "#{data_disk_type}"
+      expect(data['settings']['kind']).to eq "#{kind}"
+      expect(data['settings']['pricingPlan']).to eq "#{pricing_plan}"
+      expect(data['settings']['replicationType']).to eq "#{replication_type}"
+      expect(data['settings']['storageAutoResize']).to eq storage_auto_resize
+      expect(data['settings']['storageAutoResizeLimit']).to eq "#{storage_auto_resize_limit}"
+      expect(data['settings']['tier']).to eq "#{tier}"
+    end
+
+    it "backend type is valid" do
+      expect(data['backendType']).to eq 'SECOND_GEN'
+    end
+
+    it "database versions is valid" do
+      expect(data['databaseVersion']).to eq db_version
+    end
+
+    it "state is valid" do
+      expect(data['state']).to eq 'RUNNABLE'
+    end
+
+    it "region is valid" do
+      expect(data['region']).to eq region
+    end
+
+    it "gce zone is valid" do
+      expect(data['gceZone']).to eq "#{region}-c"
+    end
+
+    it "location preference is valid" do
+      expect(data['settings']['locationPreference']).to include(
+      "kind" => "sql#locationPreference",
+      "zone" => "#{region}-c")
+    end
+
+    it "maintenance window is valid" do
+      expect(data['settings']['maintenanceWindow']).to include(
+      "kind" => "sql#maintenanceWindow",
+      "day" => 1,
+      "hour" => 23,
+      "updateTrack" => "canary")
+    end
+  end
 
   describe "Postgres SQL pubic instance" do
     it "has just one assigned IP address" do
-      expect(instance_ip_addresses.count).to eq(1)
+      expect(data["ipAddresses"].count).to eq(1)
     end
 
     it "has expected external IP address" do
-      expect(instance_ip_addresses[0].item).to eq(
+      expect(data["ipAddresses"][0]).to eq(
         {
-          type: "PRIMARY",
-          ip_address: "#{public_ip_address}"
+          "type" => "PRIMARY",
+          "ipAddress" => "#{public_ip_address}"
         }
       )
     end
   end
-
 end

--- a/test/integration/postgresql-public/inspec.yml
+++ b/test/integration/postgresql-public/inspec.yml
@@ -15,9 +15,6 @@
 name: cloud-sql
 title: Google Cloud SQL
 version: 0.1.0
-depends:
-  - name: inspec-gcp
-    url: https://github.com/inspec/inspec-gcp/archive/v0.21.4.tar.gz
 attributes:
   - name: project_id
     type: string

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -17,7 +17,9 @@
 locals {
   int_required_roles = [
     "roles/cloudsql.admin",
-    "roles/compute.networkAdmin"
+    "roles/compute.networkAdmin",
+    "roles/iam.serviceAccountAdmin",
+    "roles/resourcemanager.projectIamAdmin",
   ]
 }
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -45,5 +45,6 @@ module "project" {
     "compute.googleapis.com",
     "servicenetworking.googleapis.com",
     "sqladmin.googleapis.com",
+    "iam.googleapis.com",
   ]
 }


### PR DESCRIPTION
This PR includes an new example module i.e. postgresql-public-iam and extension to the postgresql module that now allows users to create "iam_users" in the following format:

  iam_users = [
    {
      name          = "cloudsql-pg-sa-01"
      description   = "A service account to access postgres databases 01"
      is_account_sa = true
    },
    {
      name          = "dbadmin@goosecorp.org"
      description   = null
      is_account_sa = false
    },
]