### PR TITLE
Postgres additional_users: prevent null from being passed as password

### DIFF
--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -172,7 +172,7 @@ resource "google_sql_user" "additional_users" {
   for_each   = local.users
   project    = var.project_id
   name       = each.value.name
-  password   = lookup(each.value, "password", random_id.user-password.hex)
+  password   = coalesce(each.value["password"], random_id.user-password.hex)
   instance   = google_sql_database_instance.default.name
   depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }


### PR DESCRIPTION
This is a fix for the issue referenced [here](https://github.com/terraform-google-modules/terraform-google-sql-db/issues/222). The cause was due to terraform interpreting `null` as a literal value instead of using the default value. It seems to have been an issue for awhile and is referenced in this [terraform thread](https://github.com/hashicorp/terraform/issues/21702).