### PR TITLE
Update null and random providers

### DIFF
--- a/examples/mssql-public/main.tf
+++ b/examples/mssql-public/main.tf
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-provider "google-beta" {
-  version = ">= 3.1.0, <4.0.0"
-  region  = var.region
-}
-
 module "mssql" {
   source               = "../../modules/mssql"
   name                 = var.name

--- a/examples/mysql-ha/main.tf
+++ b/examples/mysql-ha/main.tf
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-provider "google" {
-  version = "~> 3.22"
-}
-
-provider "null" {
-  version = "~> 3.1.0"
-}
-
-provider "random" {
-  version = "~> 3.1.0"
-}
-
 locals {
   read_replica_ip_configuration = {
     ipv4_enabled    = true

--- a/examples/mysql-ha/main.tf
+++ b/examples/mysql-ha/main.tf
@@ -19,11 +19,11 @@ provider "google" {
 }
 
 provider "null" {
-  version = "~> 2.1"
+  version = "~> 3.1.0"
 }
 
 provider "random" {
-  version = "~> 2.2"
+  version = "~> 3.1.0"
 }
 
 locals {

--- a/examples/mysql-private/main.tf
+++ b/examples/mysql-private/main.tf
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-provider "google" {
-  version = "~> 3.22"
-}
-
-provider "google-beta" {
-  version = "~> 3.22"
-}
-
-provider "null" {
-  version = "~> 3.1.0"
-}
-
-provider "random" {
-  version = "~> 3.1.0"
-}
-
 resource "random_id" "suffix" {
   byte_length = 5
 }

--- a/examples/mysql-private/main.tf
+++ b/examples/mysql-private/main.tf
@@ -23,7 +23,7 @@ provider "google-beta" {
 }
 
 provider "null" {
-  version = "~>3.1.0"
+  version = "~> 3.1.0"
 }
 
 provider "random" {

--- a/examples/mysql-private/main.tf
+++ b/examples/mysql-private/main.tf
@@ -23,11 +23,11 @@ provider "google-beta" {
 }
 
 provider "null" {
-  version = "~> 2.1"
+  version = "~>3.1.0"
 }
 
 provider "random" {
-  version = "~> 2.2"
+  version = "~> 3.1.0"
 }
 
 resource "random_id" "suffix" {

--- a/examples/mysql-public/main.tf
+++ b/examples/mysql-public/main.tf
@@ -19,11 +19,11 @@ provider "google" {
 }
 
 provider "null" {
-  version = "~> 2.1"
+  version = "~>3.1.0"
 }
 
 provider "random" {
-  version = "~> 2.2"
+  version = "~> 3.1.0"
 }
 
 resource "random_id" "name" {

--- a/examples/mysql-public/main.tf
+++ b/examples/mysql-public/main.tf
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-provider "google" {
-  version = "~> 3.22"
-}
-
-provider "null" {
-  version = "~> 3.1.0"
-}
-
-provider "random" {
-  version = "~> 3.1.0"
-}
-
 resource "random_id" "name" {
   byte_length = 2
 }

--- a/examples/mysql-public/main.tf
+++ b/examples/mysql-public/main.tf
@@ -19,7 +19,7 @@ provider "google" {
 }
 
 provider "null" {
-  version = "~>3.1.0"
+  version = "~> 3.1.0"
 }
 
 provider "random" {

--- a/examples/postgresql-ha/main.tf
+++ b/examples/postgresql-ha/main.tf
@@ -14,17 +14,6 @@
  * limitations under the License.
  */
 
-provider "google" {
-  version = "~> 3.22"
-}
-
-provider "null" {
-  version = "~> 3.1.0"
-}
-
-provider "random" {
-  version = "~> 3.1.0"
-}
 
 locals {
   read_replica_ip_configuration = {

--- a/examples/postgresql-ha/main.tf
+++ b/examples/postgresql-ha/main.tf
@@ -19,11 +19,11 @@ provider "google" {
 }
 
 provider "null" {
-  version = "~> 2.1"
+  version = "~>3.1.0"
 }
 
 provider "random" {
-  version = "~> 2.2"
+  version = "~> 3.1.0"
 }
 
 locals {

--- a/examples/postgresql-ha/main.tf
+++ b/examples/postgresql-ha/main.tf
@@ -19,7 +19,7 @@ provider "google" {
 }
 
 provider "null" {
-  version = "~>3.1.0"
+  version = "~> 3.1.0"
 }
 
 provider "random" {

--- a/examples/postgresql-public-iam/main.tf
+++ b/examples/postgresql-public-iam/main.tf
@@ -23,11 +23,11 @@ provider "google-beta" {
 }
 
 provider "null" {
-  version = "~> 2.1"
+  version = "~>3.1.0"
 }
 
 provider "random" {
-  version = "~> 2.2"
+  version = "~> 3.1.0"
 }
 
 module "postgresql-db" {

--- a/examples/postgresql-public-iam/main.tf
+++ b/examples/postgresql-public-iam/main.tf
@@ -23,7 +23,7 @@ provider "google-beta" {
 }
 
 provider "null" {
-  version = "~>3.1.0"
+  version = "~> 3.1.0"
 }
 
 provider "random" {

--- a/examples/postgresql-public-iam/main.tf
+++ b/examples/postgresql-public-iam/main.tf
@@ -14,21 +14,6 @@
  * limitations under the License.
  */
 
-provider "google" {
-  version = "~> 3.22"
-}
-
-provider "google-beta" {
-  version = "~> 3.5"
-}
-
-provider "null" {
-  version = "~> 3.1.0"
-}
-
-provider "random" {
-  version = "~> 3.1.0"
-}
 
 module "postgresql-db" {
   source               = "../../modules/postgresql"

--- a/examples/postgresql-public/main.tf
+++ b/examples/postgresql-public/main.tf
@@ -23,11 +23,11 @@ provider "google-beta" {
 }
 
 provider "null" {
-  version = "~> 2.1"
+  version = "~>3.1.0"
 }
 
 provider "random" {
-  version = "~> 2.2"
+  version = "~> 3.1.0"
 }
 
 module "postgresql-db" {

--- a/examples/postgresql-public/main.tf
+++ b/examples/postgresql-public/main.tf
@@ -23,7 +23,7 @@ provider "google-beta" {
 }
 
 provider "null" {
-  version = "~>3.1.0"
+  version = "~> 3.1.0"
 }
 
 provider "random" {

--- a/examples/postgresql-public/main.tf
+++ b/examples/postgresql-public/main.tf
@@ -14,21 +14,6 @@
  * limitations under the License.
  */
 
-provider "google" {
-  version = "~> 3.22"
-}
-
-provider "google-beta" {
-  version = "~> 3.5"
-}
-
-provider "null" {
-  version = "~> 3.1.0"
-}
-
-provider "random" {
-  version = "~> 3.1.0"
-}
 
 module "postgresql-db" {
   source               = "../../modules/postgresql"

--- a/modules/mysql/versions.tf
+++ b/modules/mysql/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = "~> 3.1.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = "~> 3.1.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = "~> 3.1.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = "~> 3.1.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/modules/private_service_access/versions.tf
+++ b/modules/private_service_access/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = "~> 3.1.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -23,7 +23,7 @@ provider "google-beta" {
 }
 
 provider "null" {
-  version = "~>3.1.0"
+  version = "~> 3.1.0"
 }
 
 provider "random" {

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -23,11 +23,11 @@ provider "google-beta" {
 }
 
 provider "null" {
-  version = "~> 2.1"
+  version = "~>3.1.0"
 }
 
 provider "random" {
-  version = "~> 2.2"
+  version = "~> 3.1.0"
 }
 
 module "project" {

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-provider "google" {
-  version = "~> 3.53"
-}
-
-provider "google-beta" {
-  version = "~> 3.53"
-}
-
-provider "null" {
-  version = "~> 3.1.0"
-}
-
-provider "random" {
-  version = "~> 3.1.0"
-}
-
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0"


### PR DESCRIPTION
## Fix issue

https://github.com/terraform-google-modules/terraform-google-sql-db/issues/227

## Context

- Update `hashicorp/null` and `hashicorp/random` providers to `3.1.0` to keep up with providers updates.
- Remove provider constraints from fixtures since providers versions are pinned with `required_provider` 
