### PR TITLE
Adding option to enable insights for replica instances

### DIFF
--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -54,6 +54,16 @@ resource "google_sql_database_instance" "replicas" {
         }
       }
     }
+    dynamic "insights_config" {
+      for_each = var.insights_config != null ? [var.insights_config] : []
+
+      content {
+        query_insights_enabled  = true
+        query_string_length     = lookup(insights_config.value, "query_string_length", 1024)
+        record_application_tags = lookup(insights_config.value, "record_application_tags", false)
+        record_client_address   = lookup(insights_config.value, "record_client_address", false)
+      }
+    }
 
     disk_autoresize = lookup(each.value, "disk_autoresize", var.disk_autoresize)
     disk_size       = lookup(each.value, "disk_size", var.disk_size)


### PR DESCRIPTION
GCP now has option to enable Query Insights also for replica instances and this PR will enable it to set this via terraform