### PR TITLE
Add encryption key capability for read replicas

### DIFF
--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -36,6 +36,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | project\_id | The project ID to manage the Cloud SQL resources | `string` | n/a | yes |
 | random\_instance\_name | Sets random suffix at the end of the Cloud SQL resource name | `bool` | `false` | no |
 | read\_replica\_deletion\_protection | Used to block Terraform from deleting replica SQL Instances. | `bool` | `false` | no |
+| read\_replica\_encryption\_key\_name | The full path to the encryption key used for the CMEK disk encryption or read reaplicas | `string` | `null` | no |
 | read\_replica\_name\_suffix | The optional suffix to add to the read instance name | `string` | `""` | no |
 | read\_replicas | List of read replicas to create | <pre>list(object({<br>    name            = string<br>    tier            = string<br>    zone            = string<br>    disk_type       = string<br>    disk_autoresize = bool<br>    disk_size       = string<br>    user_labels     = map(string)<br>    database_flags = list(object({<br>      name  = string<br>      value = string<br>    }))<br>    ip_configuration = object({<br>      authorized_networks = list(map(string))<br>      ipv4_enabled        = bool<br>      private_network     = string<br>      require_ssl         = bool<br>    })<br>  }))</pre> | `[]` | no |
 | region | The region of the Cloud SQL resources | `string` | `"us-central1"` | no |

--- a/modules/mysql/read_replica.tf
+++ b/modules/mysql/read_replica.tf
@@ -21,12 +21,14 @@ locals {
 }
 
 resource "google_sql_database_instance" "replicas" {
+  provider             = google-beta
   for_each             = local.replicas
   project              = var.project_id
   name                 = "${local.master_instance_name}-replica${var.read_replica_name_suffix}${each.value.name}"
   database_version     = var.database_version
   region               = join("-", slice(split("-", lookup(each.value, "zone", var.zone)), 0, 2))
   master_instance_name = google_sql_database_instance.default.name
+  encryption_key_name  = var.read_replica_encryption_key_name
   deletion_protection  = var.read_replica_deletion_protection
 
   replica_configuration {

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -270,6 +270,12 @@ variable "encryption_key_name" {
   default     = null
 }
 
+variable "read_replica_encryption_key_name" {
+  description = "The full path to the encryption key used for the CMEK disk encryption or read reaplicas"
+  type        = string
+  default     = null
+}
+
 variable "module_depends_on" {
   description = "List of modules or resources this module depends on."
   type        = list(any)

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -38,6 +38,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | project\_id | The project ID to manage the Cloud SQL resources | `string` | n/a | yes |
 | random\_instance\_name | Sets random suffix at the end of the Cloud SQL resource name | `bool` | `false` | no |
 | read\_replica\_deletion\_protection | Used to block Terraform from deleting replica SQL Instances. | `bool` | `false` | no |
+| read\_replica\_encryption\_key\_name | The full path to the encryption key used for the CMEK disk encryption or read reaplicas | `string` | `null` | no |
 | read\_replica\_name\_suffix | The optional suffix to add to the read instance name | `string` | `""` | no |
 | read\_replicas | List of read replicas to create | <pre>list(object({<br>    name            = string<br>    tier            = string<br>    zone            = string<br>    disk_type       = string<br>    disk_autoresize = bool<br>    disk_size       = string<br>    user_labels     = map(string)<br>    database_flags = list(object({<br>      name  = string<br>      value = string<br>    }))<br>    ip_configuration = object({<br>      authorized_networks = list(map(string))<br>      ipv4_enabled        = bool<br>      private_network     = string<br>      require_ssl         = bool<br>    })<br>  }))</pre> | `[]` | no |
 | region | The region of the Cloud SQL resources | `string` | `"us-central1"` | no |

--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -21,12 +21,14 @@ locals {
 }
 
 resource "google_sql_database_instance" "replicas" {
+  provider             = google-beta
   for_each             = local.replicas
   project              = var.project_id
   name                 = "${local.master_instance_name}-replica${var.read_replica_name_suffix}${each.value.name}"
   database_version     = var.database_version
   region               = join("-", slice(split("-", lookup(each.value, "zone", var.zone)), 0, 2))
   master_instance_name = google_sql_database_instance.default.name
+  encryption_key_name  = var.read_replica_encryption_key_name
   deletion_protection  = var.read_replica_deletion_protection
 
   replica_configuration {

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -280,6 +280,12 @@ variable "encryption_key_name" {
   default     = null
 }
 
+variable "read_replica_encryption_key_name" {
+  description = "The full path to the encryption key used for the CMEK disk encryption or read reaplicas"
+  type        = string
+  default     = null
+}
+
 variable "module_depends_on" {
   description = "List of modules or resources this module depends on."
   type        = list(any)


### PR DESCRIPTION
This PR will add `encryption_key_name` to the read replica instances.
This PR fixes #249 