### PR TITLE
Upgrade `hashicorp/google` and `hashicorp/google-beta` versions

### DIFF
--- a/examples/mysql-private/main.tf
+++ b/examples/mysql-private/main.tf
@@ -29,7 +29,7 @@ locals {
 
 module "network-safer-mysql-simple" {
   source  = "terraform-google-modules/network/google"
-  version = "~> 2.5"
+  version = "~> 4.1.0"
 
   project_id   = var.project_id
   network_name = local.network_name

--- a/modules/mssql/versions.tf
+++ b/modules/mssql/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.60"
+      version = "~> 4.8.0"
     }
   }
 

--- a/modules/mysql/versions.tf
+++ b/modules/mysql/versions.tf
@@ -27,7 +27,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.60"
+      version = "~> 4.8.0"
     }
   }
 

--- a/modules/private_service_access/versions.tf
+++ b/modules/private_service_access/versions.tf
@@ -23,11 +23,11 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.53"
+      version = "~> 4.8.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.53"
+      version = "~> 4.8.0"
     }
   }
 

--- a/modules/safer_mysql/versions.tf
+++ b/modules/safer_mysql/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.60"
+      version = "~> 4.8.0"
     }
   }
 


### PR DESCRIPTION
Hi there, in need for using a recent version of `hashicorp/google` and `hashicorp/google-beta` modules in my project, I got stuck with a sub-dependency clash caused by `terraform-google-sql-db` using almost a year-old `hashicorp/google` and `hashicorp/google-beta` versions. It sounds legitimate to me to propose a bump, what would you think upgrading to latest ?

Notet that I also had to upgrade `terraform-google-modules/network/google` for the same matter.

I didn't find any blocker inside these changelogs (please correct me if I'm wrong)
- [hashicorp/google changelog](https://github.com/hashicorp/terraform-provider-google/blob/master/CHANGELOG.md)
- [hashicorp/google-beta changelog](https://github.com/hashicorp/terraform-provider-google-beta/blob/master/CHANGELOG.md)
- [terraform-google-modules/network/google changelog](https://github.com/terraform-google-modules/terraform-google-network/blob/master/CHANGELOG.md)

I ran `terraform init` tests locally with success 

```
[root@c6d3d901da43 workspace]# kitchen list
Instance                     Driver     Provisioner  Verifier   Transport  Last Action  Last Error
mysql-public-local           Terraform  Terraform    Terraform  Exec       Created      <None>
postgresql-public-local      Terraform  Terraform    Terraform  Exec       Created      <None>
postgresql-public-iam-local  Terraform  Terraform    Terraform  Exec       Created      <None>
mysql-private-local          Terraform  Terraform    Terraform  Exec       Created      <None>
mssql-public-local           Terraform  Terraform    Terraform  Exec       Created      <None>
mysql-ha-local               Terraform  Terraform    Terraform  Exec       Created      <None>
postgresql-ha-local          Terraform  Terraform    Terraform  Exec       Created      <None>
mssql-ha-local               Terraform  Terraform    Terraform  Exec       Created      <None>
```