### PR TITLE
Ignore changes to root_password

### DIFF
--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -118,7 +118,8 @@ resource "google_sql_database_instance" "default" {
 
   lifecycle {
     ignore_changes = [
-      settings[0].disk_size
+      settings[0].disk_size,
+      root_password
     ]
   }
 


### PR DESCRIPTION
root_password can only be set by the provider when
the instance is provisioned and it seems that even if
the provider could read the password then one would not
wish to destroy and recreate the instance because the
password did not match what was in Terraform.

This is specifically relevant to emergency maintenance
where somebody might have to re-import a cloned version
of the SQL server into state in a cleanup exercise. The
imported server has a null root_password because that is
what the provider has to set it to on import. The password
currently present in the state in this scenario will force
a destroy and create of the instance because of this
change.

The way to avoid this is to ignore changes for root_password