### PR TITLE
Add missing google-beta provider to required_providers

### DIFF
--- a/modules/mysql/versions.tf
+++ b/modules/mysql/versions.tf
@@ -30,7 +30,7 @@ terraform {
       version = ">= 4.4.0, < 5.0"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 4.4.0, < 5.0"
     }
   }

--- a/modules/mysql/versions.tf
+++ b/modules/mysql/versions.tf
@@ -29,9 +29,16 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 4.4.0, < 5.0"
     }
+    google-beta = {
+      source  = "hashicorp/google"
+      version = ">= 4.4.0, < 5.0"
+    }
   }
 
   provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-sql-db:mysql/v10.0.0"
+  }
+  provider_meta "google-beta" {
     module_name = "blueprints/terraform/terraform-google-sql-db:mysql/v10.0.0"
   }
 

--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -38,5 +38,8 @@ terraform {
   provider_meta "google" {
     module_name = "blueprints/terraform/terraform-google-sql-db:postgresql/v10.0.0"
   }
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/terraform-google-sql-db:postgresql/v10.0.0"
+  }
 
 }

--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -29,6 +29,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 4.4.0, < 5.0"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 4.4.0, < 5.0"
+    }
   }
 
   provider_meta "google" {


### PR DESCRIPTION
You are using the google-beta provider in `main.tf`, but it's not declared in the `required_providers` block, which creates a warning on each run.