### PR TITLE
use random_password instead of random_id

### DIFF
--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -152,23 +152,25 @@ resource "google_sql_database" "additional_databases" {
   depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }
 
-resource "random_id" "user-password" {
+resource "random_password" "user-password" {
   keepers = {
     name = google_sql_database_instance.default.name
   }
 
-  byte_length = 8
-  depends_on  = [null_resource.module_depends_on, google_sql_database_instance.default]
+  length     = 32
+  special    = false
+  depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }
 
-resource "random_id" "additional_passwords" {
+resource "random_password" "additional_passwords" {
   for_each = local.users
   keepers = {
     name = google_sql_database_instance.default.name
   }
 
-  byte_length = 8
-  depends_on  = [null_resource.module_depends_on, google_sql_database_instance.default]
+  length     = 32
+  special    = false
+  depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }
 
 resource "google_sql_user" "default" {
@@ -177,7 +179,7 @@ resource "google_sql_user" "default" {
   project  = var.project_id
   instance = google_sql_database_instance.default.name
   host     = var.user_host
-  password = var.user_password == "" ? random_id.user-password.hex : var.user_password
+  password = var.user_password == "" ? random_password.user-password.result : var.user_password
   depends_on = [
     null_resource.module_depends_on,
     google_sql_database_instance.default,
@@ -189,7 +191,7 @@ resource "google_sql_user" "additional_users" {
   for_each = local.users
   project  = var.project_id
   name     = each.value.name
-  password = lookup(each.value, "password", random_id.user-password.hex)
+  password = lookup(each.value, "password", random_password.user-password.result)
   host     = lookup(each.value, "host", var.user_host)
   instance = google_sql_database_instance.default.name
   type     = lookup(each.value, "type", "BUILT_IN")

--- a/modules/mysql/outputs.tf
+++ b/modules/mysql/outputs.tf
@@ -88,7 +88,7 @@ output "read_replica_instance_names" {
 
 output "generated_user_password" {
   description = "The auto generated default user password if not input password was provided"
-  value       = random_id.user-password.hex
+  value       = random_password.user-password.result
   sensitive   = true
 }
 

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -163,23 +163,25 @@ resource "google_sql_database" "additional_databases" {
   depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }
 
-resource "random_id" "user-password" {
+resource "random_password" "user-password" {
   keepers = {
     name = google_sql_database_instance.default.name
   }
 
-  byte_length = 8
-  depends_on  = [null_resource.module_depends_on, google_sql_database_instance.default]
+  length     = 32
+  special    = false
+  depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }
 
-resource "random_id" "additional_passwords" {
+resource "random_password" "additional_passwords" {
   for_each = local.users
   keepers = {
     name = google_sql_database_instance.default.name
   }
 
-  byte_length = 8
-  depends_on  = [null_resource.module_depends_on, google_sql_database_instance.default]
+  length     = 32
+  special    = false
+  depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }
 
 resource "google_sql_user" "default" {
@@ -187,7 +189,7 @@ resource "google_sql_user" "default" {
   name     = var.user_name
   project  = var.project_id
   instance = google_sql_database_instance.default.name
-  password = var.user_password == "" ? random_id.user-password.hex : var.user_password
+  password = var.user_password == "" ? random_password.user-password.result : var.user_password
   depends_on = [
     null_resource.module_depends_on,
     google_sql_database_instance.default,
@@ -199,7 +201,7 @@ resource "google_sql_user" "additional_users" {
   for_each = local.users
   project  = var.project_id
   name     = each.value.name
-  password = coalesce(each.value["password"], random_id.additional_passwords[each.value.name].hex)
+  password = coalesce(each.value["password"], random_password.additional_passwords[each.value.name].result)
   instance = google_sql_database_instance.default.name
   depends_on = [
     null_resource.module_depends_on,

--- a/modules/postgresql/outputs.tf
+++ b/modules/postgresql/outputs.tf
@@ -93,7 +93,7 @@ output "read_replica_instance_names" {
 
 output "generated_user_password" {
   description = "The auto generated default user password if not input password was provided"
-  value       = random_id.user-password.hex
+  value       = random_password.user-password.result
   sensitive   = true
 }
 


### PR DESCRIPTION
- random_id byte_length = 8 (integers) contains 26.6 bits of
  entropy. hex encoding does not change that entropy.
  Instead use random_password length = 32 restricted to (upper,
  lower, int) which contains 190.5 bits of entropy.
- Restrict random_password to special = false to prevent issues
  with allowed characters.