### PR TITLE
Add a description variable for google_compute_global_address resource

### DIFF
--- a/modules/private_service_access/README.md
+++ b/modules/private_service_access/README.md
@@ -16,6 +16,7 @@ that are connected to the same VPC.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | address | First IP address of the IP range to allocate to CLoud SQL instances and other Private Service Access services. If not set, GCP will pick a valid one for you. | `string` | `""` | no |
+| description | An optional description of the Global Address resource. | `string` | `""` | no |
 | ip\_version | IP Version for the allocation. Can be IPV4 or IPV6. | `string` | `""` | no |
 | labels | The key/value labels for the IP range allocated to the peered network. | `map(string)` | `{}` | no |
 | prefix\_length | Prefix length of the IP range reserved for Cloud SQL instances and other Private Service Access services. Defaults to /16. | `number` | `16` | no |

--- a/modules/private_service_access/main.tf
+++ b/modules/private_service_access/main.tf
@@ -28,6 +28,7 @@ resource "google_compute_global_address" "google-managed-services-range" {
   provider      = google-beta
   project       = var.project_id
   name          = "google-managed-services-${var.vpc_network}"
+  description   = var.description
   purpose       = "VPC_PEERING"
   address       = var.address
   prefix_length = var.prefix_length

--- a/modules/private_service_access/main.tf
+++ b/modules/private_service_access/main.tf
@@ -17,7 +17,6 @@
 data "google_compute_network" "main" {
   name    = var.vpc_network
   project = var.project_id
-
 }
 
 // We define a VPC peering subnet that will be peered with the

--- a/modules/private_service_access/variables.tf
+++ b/modules/private_service_access/variables.tf
@@ -30,6 +30,12 @@ variable "address" {
   default     = ""
 }
 
+variable "description" {
+  description = "An optional description of the Global Address resource."
+  type        = string
+  default     = ""
+}
+
 variable "prefix_length" {
   description = "Prefix length of the IP range reserved for Cloud SQL instances and other Private Service Access services. Defaults to /16."
   type        = number


### PR DESCRIPTION
To allow importing existing resources into the module as missing description forces a replacement.