### PR TITLE
fix: Add sensitive flag for MySQL module outputs

### DIFF
--- a/modules/mysql/outputs.tf
+++ b/modules/mysql/outputs.tf
@@ -117,14 +117,17 @@ output "private_ip_address" {
 output "primary" {
   value       = google_sql_database_instance.default
   description = "The `google_sql_database_instance` resource representing the primary instance"
+  sensitive   = true
 }
 
 output "replicas" {
   value       = values(google_sql_database_instance.replicas)
   description = "A list of `google_sql_database_instance` resources representing the replicas"
+  sensitive   = true
 }
 
 output "instances" {
   value       = concat([google_sql_database_instance.default], values(google_sql_database_instance.replicas))
   description = "A list of all `google_sql_database_instance` resources we've created"
+  sensitive   = true
 }


### PR DESCRIPTION
running terraform plan on MySQL module was generating errors
because the values in these outputs are considered sensitive.

## Before:


## After:
<img width="541" alt="Screen Shot 2022-05-20 at 09 42 05" src="https://user-images.githubusercontent.com/53193260/169564166-ef4aa7e7-bc07-4790-a890-32df4eb8a4fc.png">

