### PR TITLE
feat!: add support for settings.active_directory_config for SQL module

### DIFF
--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -10,6 +10,7 @@ The following dependency must be available for SQL Server module:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | activation\_policy | The activation policy for the master instance.Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | `string` | `"ALWAYS"` | no |
+| active\_directory\_config | Active domain that the SQL instance will join. | <pre>list(object({<br>    domain = string<br>  }))</pre> | `[]` | no |
 | additional\_databases | A list of databases to be created in your cluster | <pre>list(object({<br>    name      = string<br>    charset   = string<br>    collation = string<br>  }))</pre> | `[]` | no |
 | additional\_users | A list of users to be created in your cluster | <pre>list(object({<br>    name     = string<br>    password = string<br>  }))</pre> | `[]` | no |
 | availability\_type | The availability type for the master instance.This is only used to set up high availability for the MSSQL instance. Can be either `ZONAL` or `REGIONAL`. | `string` | `"ZONAL"` | no |

--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -10,7 +10,7 @@ The following dependency must be available for SQL Server module:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | activation\_policy | The activation policy for the master instance.Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | `string` | `"ALWAYS"` | no |
-| active\_directory\_config | Active domain that the SQL instance will join. | <pre>list(object({<br>    domain = string<br>  }))</pre> | `[]` | no |
+| active\_directory\_config | Active domain that the SQL instance will join. | `map(string)` | `{}` | no |
 | additional\_databases | A list of databases to be created in your cluster | <pre>list(object({<br>    name      = string<br>    charset   = string<br>    collation = string<br>  }))</pre> | `[]` | no |
 | additional\_users | A list of users to be created in your cluster | <pre>list(object({<br>    name     = string<br>    password = string<br>  }))</pre> | `[]` | no |
 | availability\_type | The availability type for the master instance.This is only used to set up high availability for the MSSQL instance. Can be either `ZONAL` or `REGIONAL`. | `string` | `"ZONAL"` | no |

--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -102,6 +102,12 @@ resource "google_sql_database_instance" "default" {
         value = lookup(database_flags.value, "value", null)
       }
     }
+    dynamic "active_directory_config" {
+      for_each = var.active_directory_config
+      content {
+        domain = lookup(active_directory_config.value, "domain", null)
+      }
+    }
 
     user_labels = var.user_labels
 

--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -105,7 +105,7 @@ resource "google_sql_database_instance" "default" {
     dynamic "active_directory_config" {
       for_each = var.active_directory_config
       content {
-        domain = lookup(active_directory_config.value, "domain", null)
+        domain =  lookup(var.active_directory_config, "domain", null)
       }
     }
 

--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -105,7 +105,7 @@ resource "google_sql_database_instance" "default" {
     dynamic "active_directory_config" {
       for_each = var.active_directory_config
       content {
-        domain =  lookup(var.active_directory_config, "domain", null)
+        domain = lookup(var.active_directory_config, "domain", null)
       }
     }
 

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -120,8 +120,8 @@ variable "database_flags" {
 
 variable "active_directory_config" {
   description = "Active domain that the SQL instance will join."
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
 }
 
 variable "user_labels" {

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -120,10 +120,8 @@ variable "database_flags" {
 
 variable "active_directory_config" {
   description = "Active domain that the SQL instance will join."
-  type = list(object({
-    domain = string
-  }))
-  default = []
+  type = map(string)
+  default = {}
 }
 
 variable "user_labels" {

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -118,6 +118,14 @@ variable "database_flags" {
   default = []
 }
 
+variable "active_directory_config" {
+  description = "Active domain that the SQL instance will join."
+  type = list(object({
+    domain = string
+  }))
+  default = []
+}
+
 variable "user_labels" {
   description = "The key/value labels for the master instances."
   type        = map(string)

--- a/modules/mssql/versions.tf
+++ b/modules/mssql/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.4.0, < 5.0"
+      version = ">= 4.22.0, < 5.0"
     }
   }
 


### PR DESCRIPTION
This change beings support for connecting SQL servers to Managed AD domain.

New feature available in [v4.22.0 provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#domain)