### PR TITLE
fix for_each issue on the sql_audit_config

### DIFF
--- a/examples/mssql-public/README.md
+++ b/examples/mssql-public/README.md
@@ -10,6 +10,7 @@ This example shows how create MS SQL Server database using the Terraform module.
 | name | The name for Cloud SQL instance | `string` | `"tf-mssql-public"` | no |
 | project\_id | The project to run tests against | `string` | n/a | yes |
 | region | n/a | `string` | `"us-central1"` | no |
+| sql\_server\_audit\_config | SQL server audit config settings. | `list(map(string))` | `[]` | no |
 
 ## Outputs
 

--- a/examples/mssql-public/README.md
+++ b/examples/mssql-public/README.md
@@ -10,7 +10,7 @@ This example shows how create MS SQL Server database using the Terraform module.
 | name | The name for Cloud SQL instance | `string` | `"tf-mssql-public"` | no |
 | project\_id | The project to run tests against | `string` | n/a | yes |
 | region | n/a | `string` | `"us-central1"` | no |
-| sql\_server\_audit\_config | SQL server audit config settings. | `list(map(string))` | `[]` | no |
+| sql\_server\_audit\_config | SQL server audit config settings. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/examples/mssql-public/main.tf
+++ b/examples/mssql-public/main.tf
@@ -23,4 +23,6 @@ module "mssql" {
   user_password        = "foobar"
 
   deletion_protection = false
+
+  sql_server_audit_config = var.sql_server_audit_config
 }

--- a/examples/mssql-public/variables.tf
+++ b/examples/mssql-public/variables.tf
@@ -31,7 +31,7 @@ variable "region" {
 }
 
 variable "sql_server_audit_config" {
-  description = "SQL server audit config settings."
+  description = "SQL server audit logs config."
   type        = list(map(string))
   default     = []
 }

--- a/examples/mssql-public/variables.tf
+++ b/examples/mssql-public/variables.tf
@@ -29,3 +29,9 @@ variable "region" {
   default = "us-central1"
   type    = string
 }
+
+variable "sql_server_audit_config" {
+  description = "SQL server audit config settings."
+  type        = list(map(string))
+  default     = []
+}

--- a/examples/mssql-public/variables.tf
+++ b/examples/mssql-public/variables.tf
@@ -31,7 +31,7 @@ variable "region" {
 }
 
 variable "sql_server_audit_config" {
-  description = "SQL server audit logs config."
-  type        = list(map(string))
-  default     = []
+  description = "SQL server audit config settings."
+  type        = map(string)
+  default     = {}
 }

--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -39,7 +39,7 @@ The following dependency must be available for SQL Server module:
 | random\_instance\_name | Sets random suffix at the end of the Cloud SQL resource name | `bool` | `false` | no |
 | region | The region of the Cloud SQL resources | `string` | `"us-central1"` | no |
 | root\_password | MSSERVER password for the root user. If not set, a random one will be generated and available in the root\_password output variable. | `string` | `""` | no |
-| sql\_server\_audit\_config | Active domain that the SQL instance will join. | `map(string)` | `{}` | no |
+| sql\_server\_audit\_config | SQL server audit config settings. | `list(map(string))` | `[]` | no |
 | tier | The tier for the master instance. | `string` | `"db-custom-2-3840"` | no |
 | update\_timeout | The optional timeout that is applied to limit long database updates. | `string` | `"15m"` | no |
 | user\_labels | The key/value labels for the master instances. | `map(string)` | `{}` | no |

--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -39,7 +39,7 @@ The following dependency must be available for SQL Server module:
 | random\_instance\_name | Sets random suffix at the end of the Cloud SQL resource name | `bool` | `false` | no |
 | region | The region of the Cloud SQL resources | `string` | `"us-central1"` | no |
 | root\_password | MSSERVER password for the root user. If not set, a random one will be generated and available in the root\_password output variable. | `string` | `""` | no |
-| sql\_server\_audit\_config | SQL server audit config settings. | `list(map(string))` | `[]` | no |
+| sql\_server\_audit\_config | SQL server audit config settings. | `map(string)` | `{}` | no |
 | tier | The tier for the master instance. | `string` | `"db-custom-2-3840"` | no |
 | update\_timeout | The optional timeout that is applied to limit long database updates. | `string` | `"15m"` | no |
 | user\_labels | The key/value labels for the master instances. | `map(string)` | `{}` | no |

--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -111,11 +111,11 @@ resource "google_sql_database_instance" "default" {
     }
 
     dynamic "sql_server_audit_config" {
-      for_each = var.sql_server_audit_config
+      for_each = length(var.sql_server_audit_config) != 0 ? [var.sql_server_audit_config] : []
       content {
-        bucket             = lookup(sql_server_audit_config.value, "bucket", null)
-        upload_interval    = lookup(sql_server_audit_config.value, "upload_interval", null)
-        retention_interval = lookup(sql_server_audit_config.value, "retention_interval", null)
+        bucket             = lookup(var.sql_server_audit_config, "bucket", null)
+        upload_interval    = lookup(var.sql_server_audit_config, "upload_interval", null)
+        retention_interval = lookup(var.sql_server_audit_config, "retention_interval", null)
       }
     }
 

--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -113,9 +113,9 @@ resource "google_sql_database_instance" "default" {
     dynamic "sql_server_audit_config" {
       for_each = var.sql_server_audit_config
       content {
-        bucket             = lookup(var.sql_server_audit_config, "bucket", null)
-        upload_interval    = lookup(var.sql_server_audit_config, "upload_interval", null)
-        retention_interval = lookup(var.sql_server_audit_config, "retention_interval", null)
+        bucket             = lookup(sql_server_audit_config.value, "bucket", null)
+        upload_interval    = lookup(sql_server_audit_config.value, "upload_interval", null)
+        retention_interval = lookup(sql_server_audit_config.value, "retention_interval", null)
       }
     }
 

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -131,9 +131,9 @@ variable "active_directory_config" {
 }
 
 variable "sql_server_audit_config" {
-  description = "Active domain that the SQL instance will join."
-  type        = map(string)
-  default     = {}
+  description = "SQL server audit config settings."
+  type        = list(map(string))
+  default     = []
 }
 
 variable "user_labels" {

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -132,8 +132,8 @@ variable "active_directory_config" {
 
 variable "sql_server_audit_config" {
   description = "SQL server audit config settings."
-  type        = list(map(string))
-  default     = []
+  type        = map(string)
+  default     = {}
 }
 
 variable "user_labels" {

--- a/test/fixtures/mssql-public/main.tf
+++ b/test/fixtures/mssql-public/main.tf
@@ -39,8 +39,21 @@ locals {
   instance_name = "${var.name}-${random_id.instance_name_suffix.hex}"
 }
 
+resource "google_storage_bucket" "sql_server_audit_logs" {
+  project       = var.project_id
+  name          = "sql-server-audit-${random_id.instance_name_suffix.hex}"
+  location      = "US"
+  force_destroy = true
+}
+
 module "mssql" {
   source     = "../../../examples/mssql-public"
   name       = local.instance_name
   project_id = var.project_id
+
+  sql_server_audit_config = [{
+    bucket             = google_storage_bucket.sql_server_audit_logs.url
+    upload_interval    = "300s"
+    retention_interval = "172800s" #2days
+  }]
 }

--- a/test/fixtures/mssql-public/main.tf
+++ b/test/fixtures/mssql-public/main.tf
@@ -51,9 +51,9 @@ module "mssql" {
   name       = local.instance_name
   project_id = var.project_id
 
-  sql_server_audit_config = [{
+  sql_server_audit_config = {
     bucket             = google_storage_bucket.sql_server_audit_logs.url
     upload_interval    = "300s"
     retention_interval = "172800s" #2days
-  }]
+  }
 }


### PR DESCRIPTION
This change converts the sql_server_audit_config from `map(string)` to `list(map(string))` where for_each was being iterated on each of the map items in `sql_server_audit_config` map. Also updated the example to test `sql_server_audit_config` variable.