### PR TITLE
chore:removing pinned version for mssql test fixtures

### DIFF
--- a/test/fixtures/mssql-ha/main.tf
+++ b/test/fixtures/mssql-ha/main.tf
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-terraform {
-  required_providers {
-    google = {
-      source = "hashicorp/google"
-      /*
-        Pinning this version due to an upstream provider issue: https://github.com/hashicorp/terraform-provider-google/issues/11891
-      */
-      version = "4.24.0"
-    }
-  }
-}
-
 provider "google" {
   region = var.region
 }

--- a/test/fixtures/mssql-public/main.tf
+++ b/test/fixtures/mssql-public/main.tf
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-terraform {
-  required_providers {
-    google = {
-      source = "hashicorp/google"
-      /*
-        Pinning this version due to an upstream provider issue: https://github.com/hashicorp/terraform-provider-google/issues/11891
-      */
-      version = "4.24.0"
-    }
-  }
-}
-
 resource "random_id" "instance_name_suffix" {
   byte_length = 5
 }


### PR DESCRIPTION
Now that [this](https://github.com/hashicorp/terraform-provider-google/issues/11891) issue is fixed, we can remove the pinned version for the provider in the test fixtures.