### PR TITLE
fix: revert null provider version to major.minor

### DIFF
--- a/modules/mysql/versions.tf
+++ b/modules/mysql/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.2"
+      version = "~> 3.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.2"
+      version = "~> 3.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/private_service_access/versions.tf
+++ b/modules/private_service_access/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.2"
+      version = "~> 3.1"
     }
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
Null provider was originally (https://github.com/terraform-google-modules/terraform-google-sql-db/blob/v12.1.0/modules/postgresql/versions.tf#L22) pessimistic pinned to a particular major.minor.patch, this reverts to just that major.minor for wider version compatibility.

Fixes #371 