### PR TITLE
Add Suffix to backup configurations

### DIFF
--- a/modules/backup/README.md
+++ b/modules/backup/README.md
@@ -66,6 +66,7 @@ fetch workflows.googleapis.com/Workflow
 | scheduler\_timezone | The Timezone in which the Scheduler Jobs are triggered | `string` | `"Etc/GMT"` | no |
 | service\_account | The service account to use for running the workflow and triggering the workflow by Cloud Scheduler - If empty or null a service account will be created. If you have provided a service account you need to grant the Cloud SQL Admin and the Workflows Invoker role to that | `string` | `null` | no |
 | sql\_instance | The name of the SQL instance to backup | `string` | n/a | yes |
+| unique\_suffix | Unique suffix to add to scheduler jobs and workflows names. | `string` | `"0"` | no |
 
 ## Outputs
 

--- a/modules/backup/README.md
+++ b/modules/backup/README.md
@@ -66,7 +66,7 @@ fetch workflows.googleapis.com/Workflow
 | scheduler\_timezone | The Timezone in which the Scheduler Jobs are triggered | `string` | `"Etc/GMT"` | no |
 | service\_account | The service account to use for running the workflow and triggering the workflow by Cloud Scheduler - If empty or null a service account will be created. If you have provided a service account you need to grant the Cloud SQL Admin and the Workflows Invoker role to that | `string` | `null` | no |
 | sql\_instance | The name of the SQL instance to backup | `string` | n/a | yes |
-| unique\_suffix | Unique suffix to add to scheduler jobs and workflows names. | `string` | `"0"` | no |
+| unique\_suffix | Unique suffix to add to scheduler jobs and workflows names. | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -59,7 +59,7 @@ data "google_sql_database_instance" "backup_instance" {
 ################################
 resource "google_workflows_workflow" "sql_backup" {
   count           = var.enable_internal_backup ? 1 : 0
-  name            = "sql-backup-${var.sql_instance}"
+  name            = "sql-backup-${var.sql_instance}-${var.unique_suffix}"
   region          = var.region
   description     = "Workflow for backing up the CloudSQL Instance "
   project         = var.project_id
@@ -73,7 +73,7 @@ resource "google_workflows_workflow" "sql_backup" {
 
 resource "google_cloud_scheduler_job" "sql_backup" {
   count       = var.enable_internal_backup ? 1 : 0
-  name        = "sql-backup-${var.sql_instance}"
+  name        = "sql-backup-${var.sql_instance}-${var.unique_suffix}"
   project     = var.project_id
   region      = var.region
   description = "Managed by Terraform - Triggers a SQL Backup via Workflows"
@@ -97,7 +97,7 @@ resource "google_cloud_scheduler_job" "sql_backup" {
 ################################
 resource "google_workflows_workflow" "sql_export" {
   count           = var.enable_export_backup ? 1 : 0
-  name            = "sql-export-${var.sql_instance}"
+  name            = "sql-export-${var.sql_instance}-${var.unique_suffix}"
   region          = var.region
   description     = "Workflow for backing up the CloudSQL Instance"
   project         = var.project_id
@@ -115,7 +115,7 @@ resource "google_workflows_workflow" "sql_export" {
 
 resource "google_cloud_scheduler_job" "sql_export" {
   count       = var.enable_export_backup ? 1 : 0
-  name        = "sql-export-${var.sql_instance}"
+  name        = "sql-export-${var.sql_instance}-${var.unique_suffix}"
   project     = var.project_id
   region      = var.region
   description = "Managed by Terraform - Triggers a SQL Export via Workflows"

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -59,7 +59,7 @@ data "google_sql_database_instance" "backup_instance" {
 ################################
 resource "google_workflows_workflow" "sql_backup" {
   count           = var.enable_internal_backup ? 1 : 0
-  name            = "sql-backup-${var.sql_instance}-${var.unique_suffix}"
+  name            = "sql-backup-${var.sql_instance}${var.unique_suffix}"
   region          = var.region
   description     = "Workflow for backing up the CloudSQL Instance "
   project         = var.project_id
@@ -73,7 +73,7 @@ resource "google_workflows_workflow" "sql_backup" {
 
 resource "google_cloud_scheduler_job" "sql_backup" {
   count       = var.enable_internal_backup ? 1 : 0
-  name        = "sql-backup-${var.sql_instance}-${var.unique_suffix}"
+  name        = "sql-backup-${var.sql_instance}${var.unique_suffix}"
   project     = var.project_id
   region      = var.region
   description = "Managed by Terraform - Triggers a SQL Backup via Workflows"
@@ -97,7 +97,7 @@ resource "google_cloud_scheduler_job" "sql_backup" {
 ################################
 resource "google_workflows_workflow" "sql_export" {
   count           = var.enable_export_backup ? 1 : 0
-  name            = "sql-export-${var.sql_instance}-${var.unique_suffix}"
+  name            = "sql-export-${var.sql_instance}${var.unique_suffix}"
   region          = var.region
   description     = "Workflow for backing up the CloudSQL Instance"
   project         = var.project_id
@@ -115,7 +115,7 @@ resource "google_workflows_workflow" "sql_export" {
 
 resource "google_cloud_scheduler_job" "sql_export" {
   count       = var.enable_export_backup ? 1 : 0
-  name        = "sql-export-${var.sql_instance}-${var.unique_suffix}"
+  name        = "sql-export-${var.sql_instance}${var.unique_suffix}"
   project     = var.project_id
   region      = var.region
   description = "Managed by Terraform - Triggers a SQL Export via Workflows"

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -93,3 +93,9 @@ variable "compress_export" {
   type        = bool
   default     = true
 }
+
+variable "unique_suffix" {
+  description = "Unique suffix to add to scheduler jobs and workflows names."
+  type        = string
+  default     = "0"
+}

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -97,5 +97,5 @@ variable "compress_export" {
 variable "unique_suffix" {
   description = "Unique suffix to add to scheduler jobs and workflows names."
   type        = string
-  default     = "0"
+  default     = ""
 }


### PR DESCRIPTION
The current setup sets an unique name for sql_instance for the backup jobs. However, it is possible that an user might want more than one backup job - for instance, a weekly, a monthly and a yearly.

The current setup does not allow having diff jobs with different retentions otherwise.