### PR TITLE
fix: remove instanceUser iam binding from the postgresql module

### DIFF
--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -215,20 +215,6 @@ resource "google_sql_user" "additional_users" {
   ]
 }
 
-resource "google_project_iam_member" "iam_binding" {
-  for_each = {
-    for iu in local.iam_users :
-    "${iu.email} ${iu.is_account_sa}" => iu
-  }
-  project = var.project_id
-  role    = "roles/cloudsql.instanceUser"
-  member = each.value.is_account_sa ? (
-    "serviceAccount:${each.value.email}"
-    ) : (
-    "user:${each.value.email}"
-  )
-}
-
 resource "google_sql_user" "iam_account" {
   for_each = {
     for iu in local.iam_users :
@@ -245,7 +231,6 @@ resource "google_sql_user" "iam_account" {
 
   depends_on = [
     null_resource.module_depends_on,
-    google_project_iam_member.iam_binding,
   ]
 }
 


### PR DESCRIPTION
It's a **breaking change**.  This PR fixes https://github.com/terraform-google-modules/terraform-google-sql-db/issues/381

The recommended way for graceful migration:
- Setup iam_binding outside the PostgreSQL module. Example:
```
locals {
  iam_user_emails = ["test-example-sa@proj-id.iam.gserviceaccount.com", "john.doe@gmail.com"]

  iam_users = [for iu in var.iam_user_emails : {
    email         = iu,
    is_account_sa = trimsuffix(iu, "gserviceaccount.com") == iu ? false : true
  }]
}

resource "google_project_iam_member" "iam_binding" {
  for_each = {
    for iu in local.iam_users :
    "${iu.email} ${iu.is_account_sa}" => iu
  }
  project = var.project_id
  role    = "roles/cloudsql.instanceUser"
  member = each.value.is_account_sa ? (
    "serviceAccount:${each.value.email}"
    ) : (
    "user:${each.value.email}"
  )
}
```
- Move resources in the terraform state:
```
terraform state mv 'module.test_example.google_project_iam_member.iam_binding["test-example-sa@proj-id.iam.gserviceaccount.com true"]' 'google_project_iam_member.iam_binding["test-example-sa@proj-id.iam.gserviceaccount.com true"]'
terraform state mv 'module.test_example.google_project_iam_member.iam_binding["john.doe@gmail.com false"]' 'google_project_iam_member.iam_binding["john.doe@gmail.com false"]'
```