### PR TITLE
fix: make special chars opt in for generated passwords

### DIFF
--- a/examples/postgresql-public-iam/main.tf
+++ b/examples/postgresql-public-iam/main.tf
@@ -44,6 +44,7 @@ module "postgresql-db" {
     password_change_interval = "3600s"
     reuse_interval           = 1
   }
+  enable_random_password_special = true
 
   database_flags = [
     {

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -28,6 +28,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | disk\_type | The disk type for the master instance. | `string` | `"PD_SSD"` | no |
 | enable\_default\_db | Enable or disable the creation of the default database | `bool` | `true` | no |
 | enable\_default\_user | Enable or disable the creation of the default user | `bool` | `true` | no |
+| enable\_random\_password\_special | Enable special characters in generated random passwords. | `bool` | `false` | no |
 | encryption\_key\_name | The full path to the encryption key used for the CMEK disk encryption | `string` | `null` | no |
 | follow\_gae\_application | A Google App Engine application whose zone to remain in. Must be in the same region as this instance. | `string` | `null` | no |
 | insights\_config | The insights\_config settings for the database. | <pre>object({<br>    query_string_length     = number<br>    record_application_tags = bool<br>    record_client_address   = bool<br>  })</pre> | `null` | no |

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -189,7 +189,7 @@ resource "random_password" "user-password" {
   }
 
   length     = 32
-  special    = true
+  special    = var.enable_random_password_special
   depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }
 
@@ -199,7 +199,7 @@ resource "random_password" "additional_passwords" {
     name = google_sql_database_instance.default.name
   }
   length     = 32
-  special    = true
+  special    = var.enable_random_password_special
   depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }
 

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -383,3 +383,9 @@ variable "enable_default_user" {
   type        = bool
   default     = true
 }
+
+variable "enable_random_password_special" {
+  description = "Enable special characters in generated random passwords."
+  type        = bool
+  default     = false
+}

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -29,6 +29,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | disk\_type | The disk type for the master instance. | `string` | `"PD_SSD"` | no |
 | enable\_default\_db | Enable or disable the creation of the default database | `bool` | `true` | no |
 | enable\_default\_user | Enable or disable the creation of the default user | `bool` | `true` | no |
+| enable\_random\_password\_special | Enable special characters in generated random passwords. | `bool` | `false` | no |
 | encryption\_key\_name | The full path to the encryption key used for the CMEK disk encryption | `string` | `null` | no |
 | follow\_gae\_application | A Google App Engine application whose zone to remain in. Must be in the same region as this instance. | `string` | `null` | no |
 | iam\_user\_emails | A list of IAM users to be created in your cluster | `list(string)` | `[]` | no |

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -199,7 +199,7 @@ resource "random_password" "user-password" {
   }
 
   length     = 32
-  special    = true
+  special    = var.enable_random_password_special
   depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }
 
@@ -209,7 +209,7 @@ resource "random_password" "additional_passwords" {
     name = google_sql_database_instance.default.name
   }
   length     = 32
-  special    = true
+  special    = var.enable_random_password_special
   depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }
 

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -385,3 +385,9 @@ variable "user_deletion_policy" {
   type        = string
   default     = null
 }
+
+variable "enable_random_password_special" {
+  description = "Enable special characters in generated random passwords."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
We did not explicitly call this out in the upgrade guide nor provide migration instructions. So adding a flag to retain backward compat.

https://github.com/terraform-google-modules/terraform-google-sql-db/issues/418