### PR TITLE
feat: provide an option to disable the Cloud Scheduler from backups

### DIFF
--- a/modules/backup/README.md
+++ b/modules/backup/README.md
@@ -48,6 +48,18 @@ fetch workflows.googleapis.com/Workflow
 | condition val() > 0 '1'
 ```
 
+## Caveats
+
+You may encounter that following error:
+
+```text
+Error: Error creating Job: googleapi: Error 403: The principal (user or service account) lacks IAM permission "cloudscheduler.jobs.create"
+```
+
+Although it may indicate what the error message is really saying, it can also mean that the Cloud Scheduler is not supported in the current region. To check if the region is supported, use the `gcloud scheduler locations list` command.
+
+In the event the region is not supported, you can pass the parameter `disable_cloud_scheduler: true` to disable the creation of Scheduler jobs. You will then have to trigger the workflows with an external process.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
@@ -56,6 +68,7 @@ fetch workflows.googleapis.com/Workflow
 | backup\_retention\_time | The number of days backups should be kept | `number` | `30` | no |
 | backup\_schedule | The cron schedule to execute the internal backup | `string` | `"45 2 * * *"` | no |
 | compress\_export | Whether or not to compress the export when storing in the bucket; Only valid for MySQL and PostgreSQL | `bool` | `true` | no |
+| disable\_cloud\_scheduler | Wether to disable Cloud Scheduler with this module. Usefull when regions does not support Cloud Scheduler. The worflows will have to be triggered manually. | `bool` | `false` | no |
 | enable\_export\_backup | Weather to create exports to GCS Buckets with this module | `bool` | `true` | no |
 | enable\_internal\_backup | Wether to create internal backups with this module | `bool` | `true` | no |
 | export\_databases | The list of databases that should be exported - if is an empty set all databases will be exported | `set(string)` | `[]` | no |

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -72,7 +72,7 @@ resource "google_workflows_workflow" "sql_backup" {
 }
 
 resource "google_cloud_scheduler_job" "sql_backup" {
-  count       = var.enable_internal_backup ? 1 : 0
+  count       = var.enable_internal_backup && !var.disable_cloud_scheduler ? 1 : 0
   name        = "sql-backup-${var.sql_instance}${var.unique_suffix}"
   project     = var.project_id
   region      = var.region
@@ -114,7 +114,7 @@ resource "google_workflows_workflow" "sql_export" {
 }
 
 resource "google_cloud_scheduler_job" "sql_export" {
-  count       = var.enable_export_backup ? 1 : 0
+  count       = var.enable_export_backup && !var.disable_cloud_scheduler ? 1 : 0
   name        = "sql-export-${var.sql_instance}${var.unique_suffix}"
   project     = var.project_id
   region      = var.region

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -102,3 +102,9 @@ variable "unique_suffix" {
   type        = string
   default     = ""
 }
+
+variable "disable_cloud_scheduler" {
+  description = "Wether to disable Cloud Scheduler with this module. Usefull when regions does not support Cloud Scheduler. The worflows will have to be triggered manually."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Cloud scheduler is not supported on all regions in GCP. For example, "europe-west4" is not supported.

Therefore, I introduced an option to be able to disable the creation of schedulers jobs. The worflows still exists and will need to be triggered with an external process, as reported by the doc.