### PR TITLE
feat: add `google_sql_user` `name` to `iam_users` output

### DIFF
--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -32,7 +32,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 | enable\_random\_password\_special | Enable special characters in generated random passwords. | `bool` | `false` | no |
 | encryption\_key\_name | The full path to the encryption key used for the CMEK disk encryption | `string` | `null` | no |
 | follow\_gae\_application | A Google App Engine application whose zone to remain in. Must be in the same region as this instance. | `string` | `null` | no |
-| iam\_users | A list of IAM users to be created in your CloudSQL instance | <pre>list(object({<br>    id    = string,<br>    email = string<br>  }))</pre> | `[]` | no |
+| iam\_users | A list of IAM account emails to create corresponding CloudSQL instance users | <pre>list(object({<br>    id    = string,<br>    email = string<br>  }))</pre> | `[]` | no |
 | insights\_config | The insights\_config settings for the database. | <pre>object({<br>    query_string_length     = number<br>    record_application_tags = bool<br>    record_client_address   = bool<br>  })</pre> | `null` | no |
 | ip\_configuration | The ip configuration for the master instances. | <pre>object({<br>    authorized_networks                           = list(map(string))<br>    ipv4_enabled                                  = bool<br>    private_network                               = string<br>    require_ssl                                   = bool<br>    allocated_ip_range                            = string<br>    enable_private_path_for_google_cloud_services = optional(bool)<br>  })</pre> | <pre>{<br>  "allocated_ip_range": null,<br>  "authorized_networks": [],<br>  "enable_private_path_for_google_cloud_services": false,<br>  "ipv4_enabled": true,<br>  "private_network": null,<br>  "require_ssl": null<br>}</pre> | no |
 | maintenance\_window\_day | The day of week (1-7) for the master instance maintenance. | `number` | `1` | no |
@@ -64,7 +64,7 @@ Note: CloudSQL provides [disk autoresize](https://cloud.google.com/sql/docs/mysq
 |------|-------------|
 | additional\_users | List of maps of additional users and passwords |
 | generated\_user\_password | The auto generated default user password if not input password was provided |
-| iam\_users | The list of the IAM users with access to the CloudSQL instance |
+| iam\_users | List of CloudSQL instance users for IAM accounts |
 | instance\_connection\_name | The connection name of the master instance to be used in connection strings |
 | instance\_first\_ip\_address | The first IPv4 address of the addresses assigned. |
 | instance\_ip\_address | The IPv4 address assigned for the master instance |

--- a/modules/postgresql/outputs.tf
+++ b/modules/postgresql/outputs.tf
@@ -109,8 +109,14 @@ output "additional_users" {
 }
 
 output "iam_users" {
-  description = "The list of the IAM users with access to the CloudSQL instance"
-  value       = var.iam_users
+  description = "List of CloudSQL instance users for IAM accounts"
+  value = [for id, r in google_sql_user.iam_account :
+    {
+      id    = id
+      email = local.iam_users[id].email
+      name  = r.name
+    }
+  ]
 }
 
 // Resources

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -323,7 +323,7 @@ variable "additional_users" {
 }
 
 variable "iam_users" {
-  description = "A list of IAM users to be created in your CloudSQL instance"
+  description = "A list of IAM account emails to create corresponding CloudSQL instance users"
   type = list(object({
     id    = string,
     email = string


### PR DESCRIPTION
Added `name` to `iam_users` output so that downstream logic does not need to repeat the IAM service account SQL username calculation (partially addresses #455, fixes #456). 

Also ensured that `iam_users` output creates an implicit dependency on the relevant `google_sql_user` resource (fixes #457). And also updated `iam_users` output docs to not imply that `cloudsql.instances.login` IAM role is also granted.

Replaced internal usage of `is_account_sa` boolean with `type` from `google_sql_user` enum string as it is theoretically possible that another type could be added like `CLOUD_IAM_GROUP`.
