### PR TITLE
fix: bump required google provider to 5.6 for postgres

### DIFF
--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -27,11 +27,11 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.80.0, < 6"
+      version = ">= 5.6, < 6"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.80.0, < 6"
+      version = ">= 5.6, < 6"
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-google-sql-db/issues/552