### PR TITLE
fix: mark replicas_instance_server_ca_certs output as sensitive

### DIFF
--- a/modules/mysql/outputs.tf
+++ b/modules/mysql/outputs.tf
@@ -48,6 +48,7 @@ output "instance_self_link" {
 output "instance_server_ca_cert" {
   value       = google_sql_database_instance.default.server_ca_cert
   description = "The CA certificate information used to connect to the SQL instance via SSL"
+  sensitive   = true
 }
 
 output "instance_service_account_email_address" {
@@ -79,6 +80,7 @@ output "replicas_instance_self_links" {
 output "replicas_instance_server_ca_certs" {
   value       = [for r in google_sql_database_instance.replicas : r.server_ca_cert]
   description = "The CA certificates information used to connect to the replica instances via SSL"
+  sensitive   = true
 }
 
 output "replicas_instance_service_account_email_addresses" {

--- a/modules/postgresql/outputs.tf
+++ b/modules/postgresql/outputs.tf
@@ -53,6 +53,7 @@ output "instance_self_link" {
 output "instance_server_ca_cert" {
   value       = google_sql_database_instance.default.server_ca_cert
   description = "The CA certificate information used to connect to the SQL instance via SSL"
+  sensitive   = true
 }
 
 output "instance_service_account_email_address" {
@@ -84,6 +85,7 @@ output "replicas_instance_self_links" {
 output "replicas_instance_server_ca_certs" {
   value       = [for r in google_sql_database_instance.replicas : r.server_ca_cert]
   description = "The CA certificates information used to connect to the replica instances via SSL"
+  sensitive   = true
 }
 
 output "replicas_instance_service_account_email_addresses" {


### PR DESCRIPTION
It should fix error for server ca cert coming from this change on google provider 5.12 and later: https://github.com/hashicorp/terraform-provider-google/pull/16932