### PR TITLE
fix: Relax assignment of backup_configuration when operating as a replica

### DIFF
--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -70,10 +70,10 @@ resource "google_sql_database_instance" "default" {
     connector_enforcement       = local.connector_enforcement
 
     dynamic "backup_configuration" {
-      for_each = var.master_instance_name != null ? [] : [var.backup_configuration]
+      for_each = [var.backup_configuration]
       content {
         binary_log_enabled             = local.binary_log_enabled
-        enabled                        = local.backups_enabled
+        enabled                        = local.backups_enabled && var.master_instance_name == null ? true : false
         start_time                     = lookup(backup_configuration.value, "start_time", null)
         location                       = lookup(backup_configuration.value, "location", null)
         transaction_log_retention_days = lookup(backup_configuration.value, "transaction_log_retention_days", null)


### PR DESCRIPTION
Relates to issue https://github.com/terraform-google-modules/terraform-google-sql-db/issues/590

In https://github.com/terraform-google-modules/terraform-google-sql-db/pull/556 and https://github.com/terraform-google-modules/terraform-google-sql-db/pull/559 I added the ability to configure the `master_instance_name` and `instance_type` on the main `google_sql_database_instance` created by this module.

The intent was to allow the module to be used for on-premises database migrations, where the primary instance would start as a replica and then later be promoted to the source.

During this change I disabled the assignment of `backup_configuration` because the docs say:
> Backups cannot be enabled on replica instances, but binary logging can be enabled on a replica even when backups are disabled, unlike the primary.

When an instance is configured with a `master_instance_name`, the instance is operating as a replica, so cannot have backups enabled. This was why I restricted configuring these values.

However, I was overzealous about which configuration items I blocked. For example, binary logging can be enabled on replicas without enabling backups (infact, it _must_ be to enable to create replicas). The only config here I should have restricted is the `enabled` option, which this PR changes.