### PR TITLE
mssql: make instance_server_ca_cert output sensitive

### DIFF
--- a/modules/mssql/outputs.tf
+++ b/modules/mssql/outputs.tf
@@ -48,6 +48,7 @@ output "instance_self_link" {
 output "instance_server_ca_cert" {
   value       = google_sql_database_instance.default.server_ca_cert
   description = "The CA certificate information used to connect to the SQL instance via SSL"
+  sensitive   = true
 }
 
 output "instance_service_account_email_address" {


### PR DESCRIPTION
This change should fix the following error `mssql` module.

│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 48:
│   48: output "instance_server_ca_cert" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true