### PR TITLE
feat: adding support for automatic creation of psc consumer

### DIFF
--- a/examples/postgresql-psc/main.tf
+++ b/examples/postgresql-psc/main.tf
@@ -25,6 +25,22 @@ locals {
   }
 }
 
+module "network-auto-psc" {
+  source  = "terraform-google-modules/network/google"
+  version = "~> 9.0"
+
+  project_id   = var.project_id
+  network_name = "your_network_name"
+
+  subnets = [
+    {
+      subnet_name   = "your-subnet"
+      subnet_ip     = "10.4.0.0/16"
+      subnet_region = "us-central1"
+    }
+  ]
+}
+
 module "pg" {
   source  = "terraform-google-modules/sql-db/google//modules/postgresql"
   version = "~> 20.0"
@@ -85,6 +101,12 @@ module "pg" {
       user_labels       = { bar = "baz" }
     },
   ]
+
+  psc_consumer = {
+    enabled    = true
+    subnet_id  = module.network-auto-psc.subnets_ids[0]
+    network_id = module.network-auto-psc.network_id
+  }
 
   db_name      = var.pg_psc_name
   db_charset   = "UTF8"

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -157,6 +157,7 @@ module "pg" {
 | password\_validation\_policy\_config | The password validation policy settings for the database instance. | <pre>object({<br>    min_length                  = optional(number)<br>    complexity                  = optional(string)<br>    reuse_interval              = optional(number)<br>    disallow_username_substring = optional(bool)<br>    password_change_interval    = optional(string)<br>  })</pre> | `null` | no |
 | pricing\_plan | The pricing plan for the Cloud SQL instance. | `string` | `"PER_USE"` | no |
 | project\_id | The project ID to manage the Cloud SQL resources | `string` | n/a | yes |
+| psc\_consumer | The psc consumer to be created on the same project as the SQL instance(s). Remember to add the project under psc\_allowed\_consumer\_projects in the ip\_configuration block. | <pre>object({<br>    subnet_id               = optional(string, "")<br>    network_id              = optional(string, "")<br>    enabled                 = optional(bool, false)<br>    allow_psc_global_access = optional(bool, false)<br>  })</pre> | `{}` | no |
 | random\_instance\_name | Sets random suffix at the end of the Cloud SQL resource name | `bool` | `false` | no |
 | read\_replica\_deletion\_protection | Used to block Terraform from deleting replica SQL Instances. | `bool` | `false` | no |
 | read\_replica\_deletion\_protection\_enabled | Enables protection of replica instance from accidental deletion across all surfaces (API, gcloud, Cloud Console and Terraform). | `bool` | `false` | no |

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -439,3 +439,28 @@ variable "data_cache_enabled" {
   type        = bool
   default     = false
 }
+
+variable "psc_consumer" {
+  description = "The psc consumer to be created on the same project as the SQL instance(s). Remember to add the project under psc_allowed_consumer_projects in the ip_configuration block."
+  type = object({
+    subnet_id               = optional(string, "")
+    network_id              = optional(string, "")
+    enabled                 = optional(bool, false)
+    allow_psc_global_access = optional(bool, false)
+  })
+
+  default = {}
+
+  validation {
+    condition     = (!var.psc_consumer.enabled || (var.psc_consumer.network_id != "" && var.psc_consumer.subnet_id != ""))
+    error_message = "In order to use the psc_consumer submodule you must specify both network and subnet id"
+  }
+}
+
+
+
+
+
+
+
+

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -22,6 +22,7 @@ locals {
     "roles/cloudsql.admin",
     "roles/compute.admin",
     "roles/compute.networkAdmin",
+    "roles/dns.admin",
     "roles/iam.serviceAccountAdmin",
     "roles/iam.serviceAccountUser",
     "roles/monitoring.editor",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -35,6 +35,7 @@ module "project" {
     "serviceusage.googleapis.com",
     "sqladmin.googleapis.com",
     "workflows.googleapis.com",
+    "dns.googleapis.com",
   ]
 }
 


### PR DESCRIPTION
When using psc you can optionally create psc consumer for main and read replica in the specified network and subnet.