### PR TITLE
feat!: Add enable_google_ml_integration setting for database instance and configurable project roles for default database service account

### DIFF
--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -126,6 +126,7 @@ module "pg" {
 | data\_cache\_enabled | Whether data cache is enabled for the instance. Defaults to false. Feature is only available for ENTERPRISE\_PLUS tier and supported database\_versions | `bool` | `false` | no |
 | database\_deletion\_policy | The deletion policy for the database. Setting ABANDON allows the resource to be abandoned rather than deleted. This is useful for Postgres, where databases cannot be deleted from the API if there are users other than cloudsqlsuperuser with access. Possible values are: "ABANDON". | `string` | `null` | no |
 | database\_flags | The database flags for the Cloud SQL instance. See [more details](https://cloud.google.com/sql/docs/postgres/flags) | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
+| database\_integration\_roles | The roles required by default database instance service account for integration with GCP services | `list(string)` | `[]` | no |
 | database\_version | The database version to use | `string` | n/a | yes |
 | db\_charset | The charset for the default database | `string` | `""` | no |
 | db\_collation | The collation for the default database. Example: 'en\_US.UTF8' | `string` | `""` | no |
@@ -141,6 +142,7 @@ module "pg" {
 | edition | The edition of the Cloud SQL instance, can be ENTERPRISE or ENTERPRISE\_PLUS. | `string` | `null` | no |
 | enable\_default\_db | Enable or disable the creation of the default database | `bool` | `true` | no |
 | enable\_default\_user | Enable or disable the creation of the default user | `bool` | `true` | no |
+| enable\_google\_ml\_integration | Enable database ML integration | `bool` | `false` | no |
 | enable\_random\_password\_special | Enable special characters in generated random passwords. | `bool` | `false` | no |
 | encryption\_key\_name | The full path to the encryption key used for the CMEK disk encryption | `string` | `null` | no |
 | follow\_gae\_application | A Google App Engine application whose zone to remain in. Must be in the same region as this instance. | `string` | `null` | no |

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -211,5 +211,5 @@ module "pg" {
 ### Installation Dependencies
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 1.3.0
-- [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) plugin v5.12+
-- [Terraform Provider Beta for GCP](https://github.com/terraform-providers/terraform-provider-google-beta) plugin v5.12+
+- [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) plugin v5.25+
+- [Terraform Provider Beta for GCP](https://github.com/terraform-providers/terraform-provider-google-beta) plugin v5.25+

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -73,6 +73,7 @@ resource "google_sql_database_instance" "default" {
     availability_type           = var.availability_type
     deletion_protection_enabled = var.deletion_protection_enabled
     connector_enforcement       = local.connector_enforcement
+    enable_google_ml_integration = var.enable_google_ml_integration
 
     dynamic "backup_configuration" {
       for_each = local.is_secondary_instance ? [] : [var.backup_configuration]
@@ -317,6 +318,13 @@ resource "google_sql_user" "iam_account" {
     null_resource.module_depends_on,
   ]
   deletion_policy = var.user_deletion_policy
+}
+
+resource "google_project_iam_member" "database_integration" {
+  for_each = toset(var.database_integration_roles)
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_sql_database_instance.default.service_account_email_address}"
 }
 
 resource "null_resource" "module_depends_on" {

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -67,12 +67,12 @@ resource "google_sql_database_instance" "default" {
   instance_type        = local.is_secondary_instance ? "READ_REPLICA_INSTANCE" : var.instance_type
 
   settings {
-    tier                        = var.tier
-    edition                     = var.edition
-    activation_policy           = var.activation_policy
-    availability_type           = var.availability_type
-    deletion_protection_enabled = var.deletion_protection_enabled
-    connector_enforcement       = local.connector_enforcement
+    tier                         = var.tier
+    edition                      = var.edition
+    activation_policy            = var.activation_policy
+    availability_type            = var.availability_type
+    deletion_protection_enabled  = var.deletion_protection_enabled
+    connector_enforcement        = local.connector_enforcement
     enable_google_ml_integration = var.enable_google_ml_integration
 
     dynamic "backup_configuration" {
@@ -322,9 +322,9 @@ resource "google_sql_user" "iam_account" {
 
 resource "google_project_iam_member" "database_integration" {
   for_each = toset(var.database_integration_roles)
-  project = var.project_id
-  role    = each.value
-  member  = "serviceAccount:${google_sql_database_instance.default.service_account_email_address}"
+  project  = var.project_id
+  role     = each.value
+  member   = "serviceAccount:${google_sql_database_instance.default.service_account_email_address}"
 }
 
 resource "null_resource" "module_depends_on" {

--- a/modules/postgresql/metadata.yaml
+++ b/modules/postgresql/metadata.yaml
@@ -122,6 +122,10 @@ spec:
               value = string
             }))
         defaultValue: []
+      - name: database_integration_roles
+        description: The roles required by default database instance service account for integration with GCP services
+        varType: list(string)
+        defaultValue: []
       - name: database_version
         description: The database version to use
         varType: string
@@ -186,6 +190,10 @@ spec:
         description: Enable or disable the creation of the default user
         varType: bool
         defaultValue: true
+      - name: enable_google_ml_integration
+        description: Enable database ML integration
+        varType: bool
+        defaultValue: false
       - name: enable_random_password_special
         description: Enable special characters in generated random passwords.
         varType: bool

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -442,12 +442,12 @@ variable "data_cache_enabled" {
 
 variable "enable_google_ml_integration" {
   description = "Enable database ML integration"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "database_integration_roles" {
   description = "The roles required by default database instance service account for integration with GCP services"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -439,3 +439,15 @@ variable "data_cache_enabled" {
   type        = bool
   default     = false
 }
+
+variable "enable_google_ml_integration" {
+  description = "Enable database ML integration"
+  type = bool
+  default = false
+}
+
+variable "database_integration_roles" {
+  description = "The roles required by default database instance service account for integration with GCP services"
+  type = list(string)
+  default = []
+}

--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -27,11 +27,11 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.12, < 6"
+      version = ">= 5.25, < 6"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.12, < 6"
+      version = ">= 5.25, < 6"
     }
   }
 


### PR DESCRIPTION
This PR makes below changes,

1. Add `enable_google_ml_integration` setting for database instance. https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#enable_google_ml_integration
2. Configurable project roles for default database service account. The default database service account is created for each database instance. To enable database to call ML functions from VertexAI etc, the service account needs suitable project roles. 

This feature has been used in "Gen AI rag with cloud sql" https://github.com/GoogleCloudPlatform/terraform-genai-rag/blob/main/database.tf#L32