### PR TITLE
feat(TPG>5.38)!: added deletion_policy to private service access sub-module and promoted to GA provider

### DIFF
--- a/examples/mssql-failover-replica/main.tf
+++ b/examples/mssql-failover-replica/main.tf
@@ -36,7 +36,7 @@ module "mssql1" {
 
   deletion_protection = false
 
-  tier = "db-custom-10-65536"
+  tier = "db-custom-4-15360"
 
   ip_configuration = {
     ipv4_enabled    = false
@@ -70,7 +70,7 @@ module "mssql2" {
 
   deletion_protection = false
 
-  tier = "db-custom-10-65536"
+  tier = "db-custom-4-15360"
 
   ip_configuration = {
     ipv4_enabled    = false

--- a/examples/mssql-failover-replica/main.tf
+++ b/examples/mssql-failover-replica/main.tf
@@ -24,7 +24,7 @@ locals {
 
 module "mssql1" {
   source  = "terraform-google-modules/sql-db/google//modules/mssql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   region = local.region_1
 
@@ -56,7 +56,7 @@ module "mssql1" {
 
 module "mssql2" {
   source  = "terraform-google-modules/sql-db/google//modules/mssql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   master_instance_name = module.mssql1.instance_name
 

--- a/examples/mysql-backup-create-service-account/main.tf
+++ b/examples/mysql-backup-create-service-account/main.tf
@@ -16,7 +16,7 @@
 
 module "mysql" {
   source  = "terraform-google-modules/sql-db/google//modules/mysql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   name                 = "example-mysql-public"
   database_version     = "MYSQL_8_0"
@@ -45,7 +45,7 @@ resource "google_storage_bucket" "backup" {
 
 module "backup" {
   source  = "terraform-google-modules/sql-db/google//modules/backup"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   region                = "us-central1"
   project_id            = var.project_id

--- a/examples/mysql-ha/main.tf
+++ b/examples/mysql-ha/main.tf
@@ -33,7 +33,7 @@ locals {
 
 module "mysql" {
   source  = "terraform-google-modules/sql-db/google//modules/mysql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   name                 = var.mysql_ha_name
   random_instance_name = true

--- a/examples/mysql-private/main.tf
+++ b/examples/mysql-private/main.tf
@@ -39,7 +39,7 @@ module "network-safer-mysql-simple" {
 
 module "private-service-access" {
   source  = "terraform-google-modules/sql-db/google//modules/private_service_access"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   project_id  = var.project_id
   vpc_network = module.network-safer-mysql-simple.network_name
@@ -47,7 +47,7 @@ module "private-service-access" {
 
 module "safer-mysql-db" {
   source  = "terraform-google-modules/sql-db/google//modules/safer_mysql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   name                 = var.db_name
   random_instance_name = true

--- a/examples/mysql-psc/main.tf
+++ b/examples/mysql-psc/main.tf
@@ -27,7 +27,7 @@ locals {
 
 module "mysql" {
   source  = "terraform-google-modules/sql-db/google//modules/mysql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   name                 = var.mysql_ha_name
   random_instance_name = true

--- a/examples/mysql-psc/main.tf
+++ b/examples/mysql-psc/main.tf
@@ -38,7 +38,7 @@ module "mysql" {
   deletion_protection = false
 
   // Master configurations
-  tier                            = "db-custom-4-15360"
+  tier                            = "db-custom-2-7680"
   zone                            = "us-central1-c"
   availability_type               = "REGIONAL"
   maintenance_window_day          = 7
@@ -82,7 +82,7 @@ module "mysql" {
       name              = "0"
       zone              = "us-central1-a"
       availability_type = "REGIONAL"
-      tier              = "db-custom-4-15360"
+      tier              = "db-custom-2-7680"
       ip_configuration  = local.read_replica_ip_configuration
       database_flags    = [{ name = "long_query_time", value = 1 }]
       disk_type         = "PD_SSD"

--- a/examples/mysql-public/main.tf
+++ b/examples/mysql-public/main.tf
@@ -20,7 +20,7 @@ resource "random_id" "name" {
 
 module "mysql-db" {
   source  = "terraform-google-modules/sql-db/google//modules/mysql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   name                 = var.db_name
   random_instance_name = true

--- a/examples/postgresql-backup-provided-service-account/main.tf
+++ b/examples/postgresql-backup-provided-service-account/main.tf
@@ -16,7 +16,7 @@
 
 module "postgresql" {
   source  = "terraform-google-modules/sql-db/google//modules/postgresql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   name                 = "example-postgres"
   random_instance_name = true
@@ -56,7 +56,7 @@ resource "google_monitoring_notification_channel" "email" {
 
 module "backup" {
   source  = "terraform-google-modules/sql-db/google//modules/backup"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   region                      = "us-central1"
   project_id                  = var.project_id

--- a/examples/postgresql-ha/main.tf
+++ b/examples/postgresql-ha/main.tf
@@ -33,7 +33,7 @@ locals {
 
 module "pg" {
   source  = "terraform-google-modules/sql-db/google//modules/postgresql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   name                 = var.pg_ha_name
   random_instance_name = true

--- a/examples/postgresql-psc/main.tf
+++ b/examples/postgresql-psc/main.tf
@@ -27,7 +27,7 @@ locals {
 
 module "pg" {
   source  = "terraform-google-modules/sql-db/google//modules/postgresql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   name                 = var.pg_psc_name
   random_instance_name = true

--- a/examples/postgresql-psc/main.tf
+++ b/examples/postgresql-psc/main.tf
@@ -36,7 +36,7 @@ module "pg" {
   region               = "us-central1"
 
   // Master configurations
-  tier                            = "db-custom-16-61440"
+  tier                            = "db-custom-2-7680"
   zone                            = "us-central1-c"
   availability_type               = "REGIONAL"
   maintenance_window_day          = 7
@@ -78,7 +78,7 @@ module "pg" {
       name              = "0"
       zone              = "us-central1-a"
       availability_type = "REGIONAL"
-      tier              = "db-custom-16-61440"
+      tier              = "db-custom-2-7680"
       ip_configuration  = local.read_replica_ip_configuration
       database_flags    = [{ name = "autovacuum", value = "off" }]
       disk_type         = "PD_SSD"

--- a/examples/postgresql-public-iam/main.tf
+++ b/examples/postgresql-public-iam/main.tf
@@ -17,7 +17,7 @@
 
 module "postgresql-db" {
   source  = "terraform-google-modules/sql-db/google//modules/postgresql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   name                 = var.db_name
   random_instance_name = true

--- a/examples/postgresql-public/main.tf
+++ b/examples/postgresql-public/main.tf
@@ -17,7 +17,7 @@
 
 module "postgresql-db" {
   source  = "terraform-google-modules/sql-db/google//modules/postgresql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   name                 = var.db_name
   random_instance_name = true

--- a/examples/postgresql-with-cross-region-failover/main.tf
+++ b/examples/postgresql-with-cross-region-failover/main.tf
@@ -47,7 +47,7 @@ data "google_compute_zones" "available_region2" {
 
 module "pg1" {
   source  = "terraform-google-modules/sql-db/google//modules/postgresql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
 
   name                 = var.pg_name_1
@@ -156,7 +156,7 @@ module "pg1" {
 
 module "pg2" {
   source  = "terraform-google-modules/sql-db/google//modules/postgresql"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
 
   # Comment this parameter to promot instance 2 as primary instance. This will break replication between instance 1 and 2

--- a/examples/postgresql-with-cross-region-failover/main.tf
+++ b/examples/postgresql-with-cross-region-failover/main.tf
@@ -29,7 +29,7 @@ locals {
     ]
   }
   edition            = "ENTERPRISE_PLUS"
-  tier               = local.edition == "ENTERPRISE_PLUS" ? "db-perf-optimized-N-4" : "db-custom-4-15360"
+  tier               = local.edition == "ENTERPRISE_PLUS" ? "db-perf-optimized-N-2" : "db-custom-2-7680"
   data_cache_enabled = local.edition == "ENTERPRISE_PLUS" ? true : false
 }
 

--- a/examples/private_service_access/README.md
+++ b/examples/private_service_access/README.md
@@ -1,0 +1,35 @@
+# Private Service Acces
+
+This example shows how to create private service access
+
+## Run Terraform
+
+Create resources with terraform:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+To remove all resources created by terraform:
+
+```bash
+terraform destroy
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project\_id | The project to run tests against | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| project\_id | The project to run tests against |
+| psa | psa created |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/private_service_access/main.tf
+++ b/examples/private_service_access/main.tf
@@ -14,17 +14,20 @@
  * limitations under the License.
  */
 
-module "mssql" {
-  source  = "terraform-google-modules/sql-db/google//modules/mssql"
+resource "google_compute_network" "default" {
+  name                    = "test-psa-network"
+  project                 = var.project_id
+  auto_create_subnetworks = false
+  description             = "test network"
+}
+
+module "test_psa" {
+  source  = "terraform-google-modules/sql-db/google//modules/private_service_access"
   version = "~> 21.0"
 
-  name                 = var.name
-  random_instance_name = true
-  project_id           = var.project_id
-  user_name            = "simpleuser"
-  user_password        = "foobar"
-
-  deletion_protection = false
-
-  sql_server_audit_config = var.sql_server_audit_config
+  project_id      = var.project_id
+  vpc_network     = google_compute_network.default.name
+  address         = "10.220.0.0"
+  deletion_policy = "ABANDON"
+  depends_on      = [google_compute_network.default]
 }

--- a/examples/private_service_access/outputs.tf
+++ b/examples/private_service_access/outputs.tf
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-module "mssql" {
-  source  = "terraform-google-modules/sql-db/google//modules/mssql"
-  version = "~> 21.0"
+output "project_id" {
+  description = "The project to run tests against"
+  value       = var.project_id
+}
 
-  name                 = var.name
-  random_instance_name = true
-  project_id           = var.project_id
-  user_name            = "simpleuser"
-  user_password        = "foobar"
-
-  deletion_protection = false
-
-  sql_server_audit_config = var.sql_server_audit_config
+output "psa" {
+  description = "psa created"
+  value       = module.test_psa
 }

--- a/examples/private_service_access/variables.tf
+++ b/examples/private_service_access/variables.tf
@@ -14,17 +14,7 @@
  * limitations under the License.
  */
 
-module "mssql" {
-  source  = "terraform-google-modules/sql-db/google//modules/mssql"
-  version = "~> 21.0"
-
-  name                 = var.name
-  random_instance_name = true
-  project_id           = var.project_id
-  user_name            = "simpleuser"
-  user_password        = "foobar"
-
-  deletion_protection = false
-
-  sql_server_audit_config = var.sql_server_audit_config
+variable "project_id" {
+  type        = string
+  description = "The project to run tests against"
 }

--- a/modules/private_service_access/README.md
+++ b/modules/private_service_access/README.md
@@ -1,4 +1,4 @@
-# Submodule for VPC peering Cloud SQL services
+# Submodule for Private Service Access
 
 MySQL [Private IP](https://cloud.google.com/sql/docs/mysql/private-ip)
 configurations require a special peering between your VPC network and a
@@ -10,12 +10,30 @@ that are connected to the same VPC.
 > NOTE: See the linked [documentation](https://cloud.google.com/sql/docs/mysql/private-ip)
 > for all requirements for accessing a MySQL instance via its Private IP.
 
+## Usage
+Basic usage of this module is as follows:
+
+```
+module "test_psa" {
+  source  = "terraform-google-modules/sql-db/google//modules/private_service_access"
+  version = "~> 21.0"
+
+  project_id      = var.project_id
+  vpc_network     = google_compute_network.default.name
+  address         = "10.220.0.0"
+  deletion_policy = "ABANDON"
+  depends_on      = [google_compute_network.default]
+}
+```
+
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | address | First IP address of the IP range to allocate to CLoud SQL instances and other Private Service Access services. If not set, GCP will pick a valid one for you. | `string` | `""` | no |
+| deletion\_policy | The deletion policy for the service networking connection. Setting to ABANDON allows the resource to be abandoned rather than deleted. This will enable a successful terraform destroy when destroying CloudSQL instances. Use with care as it can lead to dangling resources. | `string` | `null` | no |
 | description | An optional description of the Global Address resource. | `string` | `""` | no |
 | ip\_version | IP Version for the allocation. Can be IPV4 or IPV6. | `string` | `""` | no |
 | labels | The key/value labels for the IP range allocated to the peered network. | `map(string)` | `{}` | no |

--- a/modules/private_service_access/main.tf
+++ b/modules/private_service_access/main.tf
@@ -24,7 +24,6 @@ data "google_compute_network" "main" {
 // have a private IP within the provided range.
 // https://cloud.google.com/vpc/docs/configure-private-services-access
 resource "google_compute_global_address" "google-managed-services-range" {
-  provider      = google-beta
   project       = var.project_id
   name          = "google-managed-services-${var.vpc_network}"
   description   = var.description
@@ -39,10 +38,10 @@ resource "google_compute_global_address" "google-managed-services-range" {
 
 # Creates the peering with the producer network.
 resource "google_service_networking_connection" "private_service_access" {
-  provider                = google-beta
   network                 = data.google_compute_network.main.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.google-managed-services-range.name]
+  deletion_policy         = var.deletion_policy
 }
 
 resource "null_resource" "dependency_setter" {

--- a/modules/private_service_access/variables.tf
+++ b/modules/private_service_access/variables.tf
@@ -53,3 +53,9 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "deletion_policy" {
+  description = "The deletion policy for the service networking connection. Setting to ABANDON allows the resource to be abandoned rather than deleted. This will enable a successful terraform destroy when destroying CloudSQL instances. Use with care as it can lead to dangling resources."
+  type        = string
+  default     = null
+}

--- a/modules/private_service_access/versions.tf
+++ b/modules/private_service_access/versions.tf
@@ -23,11 +23,11 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      version = ">= 5.38, < 6"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.53, < 6"
+      version = ">= 5.38, < 6"
     }
   }
 

--- a/test/integration/mssql-failover-replica/mssql_failover_replica_test.go
+++ b/test/integration/mssql-failover-replica/mssql_failover_replica_test.go
@@ -40,7 +40,7 @@ func TestMsSqlFailoverReplica(t *testing.T) {
 		assert.Equal("SYNCHRONOUS", op.Get("settings.replicationType").String(), "Expected SYNCHRONOUS replicationType")
 		assert.True(op.Get("settings.storageAutoResize").Bool(), "Expected TRUE storageAutoResize")
 		assert.Equal(int64(0), op.Get("settings.storageAutoResizeLimit").Int(), "Expected 0 storageAutoResizeLimit")
-		assert.Equal("db-custom-10-65536", op.Get("settings.tier").String(), "Expected db-custom-10-65536 tier")
+		assert.Equal("db-custom-4-15360", op.Get("settings.tier").String(), "Expected db-custom-4-15360 tier")
 
 		// assert location database settings
 		assert.Equal("sql#locationPreference", op.Get("settings.locationPreference.kind").String(), "Expected sql#locationPreference locationPreference.kind")
@@ -69,7 +69,7 @@ func TestMsSqlFailoverReplica(t *testing.T) {
 		assert.Equal("SYNCHRONOUS", op2.Get("settings.replicationType").String(), "Expected SYNCHRONOUS replicationType")
 		assert.True(op2.Get("settings.storageAutoResize").Bool(), "Expected TRUE storageAutoResize")
 		assert.Equal(int64(0), op2.Get("settings.storageAutoResizeLimit").Int(), "Expected 0 storageAutoResizeLimit")
-		assert.Equal("db-custom-10-65536", op2.Get("settings.tier").String(), "Expected db-custom-10-65536 tier")
+		assert.Equal("db-custom-4-15360", op2.Get("settings.tier").String(), "Expected db-custom-4-15360 tier")
 
 		assert.Equal(msSql.GetStringOutput("project_id") + ":" + msSql.GetStringOutput("master_instance_name2"), op2.Get("masterInstanceName").String(), "Expected ALWAYS activationPolicy")
 

--- a/test/integration/mysql-psc/mysql_psc_test.go
+++ b/test/integration/mysql-psc/mysql_psc_test.go
@@ -47,7 +47,7 @@ func TestMySqlPscModule(t *testing.T) {
 			assert.Equal("SYNCHRONOUS", op.Get("settings.replicationType").String(), "Expected SYNCHRONOUS replicationType")
 			assert.True(op.Get("settings.storageAutoResize").Bool(), "Expected TRUE storageAutoResize")
 			assert.Equal(int64(0), op.Get("settings.storageAutoResizeLimit").Int(), "Expected 0 storageAutoResizeLimit")
-			assert.Equal("db-custom-4-15360", op.Get("settings.tier").String(), "Expected db-custom-4-15360 tier")
+			assert.Equal("db-custom-2-7680", op.Get("settings.tier").String(), "Expected db-custom-2-7680 tier")
 
 			// assert database flags
 			assert.JSONEqf(`{"name": "long_query_time", "value": "1"}`, op.Get("settings.databaseFlags").Array()[0].Raw, `Expected {"name": "long_query_time", "value": "1"} databaseFlags`)

--- a/test/integration/postgresql-psc/postgresql_psc_test.go
+++ b/test/integration/postgresql-psc/postgresql_psc_test.go
@@ -46,7 +46,7 @@ func TestPostgreSqlPscModule(t *testing.T) {
 			assert.Equal("SYNCHRONOUS", op.Get("settings.replicationType").String(), "Expected SYNCHRONOUS replicationType")
 			assert.True(op.Get("settings.storageAutoResize").Bool(), "Expected TRUE storageAutoResize")
 			assert.Equal(int64(0), op.Get("settings.storageAutoResizeLimit").Int(), "Expected 0 storageAutoResizeLimit")
-			assert.Equal("db-custom-16-61440", op.Get("settings.tier").String(), "Expected db-custom-16-61440 tier")
+			assert.Equal("db-custom-2-7680", op.Get("settings.tier").String(), "Expected db-custom-2-7680 tier")
 
 			// assert database flags
 			assert.JSONEq(`{"name": "autovacuum", "value": "off"}`, op.Get("settings.databaseFlags").Array()[0].Raw, `Expected {"name": "autovacuum", "value": "off"} databaseFlags`)

--- a/test/integration/postgresql-with-cross-region-failover/postgresql_cross_region_failover_test.go
+++ b/test/integration/postgresql-with-cross-region-failover/postgresql_cross_region_failover_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
-	// "github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,7 +46,7 @@ func TestPostgreSqlCrossRegionFailover(t *testing.T) {
 		assert.Equal("SYNCHRONOUS", op.Get("settings.replicationType").String(), "Expected SYNCHRONOUS replicationType")
 		assert.True(op.Get("settings.storageAutoResize").Bool(), "Expected TRUE storageAutoResize")
 		assert.Equal(int64(0), op.Get("settings.storageAutoResizeLimit").Int(), "Expected 0 storageAutoResizeLimit")
-		assert.Equal("db-perf-optimized-N-4", op.Get("settings.tier").String(), "Expected db-perf-optimized-N-4 tier")
+		assert.Equal("db-perf-optimized-N-2", op.Get("settings.tier").String(), "Expected db-perf-optimized-N-2 tier")
 		assert.Equal("ENTERPRISE_PLUS", op.Get("settings.edition").String(), "Expected edition ENTERPRISE_PLUS")
 		assert.True(op.Get("settings.insightsConfig.queryInsightsEnabled").Bool(), "Expected queryInsightsEnabled true")
 		assert.Equal("5", op.Get("settings.insightsConfig.queryPlansPerMinute").String(), "Expected queryPlansPerMinute 5")

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -47,3 +47,9 @@ resource "google_service_account" "cloudsql_mysql_sa" {
   project    = module.project.project_id
   account_id = "cloudsql-mysql-sa-01"
 }
+
+resource "google_project_service_identity" "workflos_sa" {
+  provider = google-beta
+  project  = module.project.project_id
+  service  = "workflows.googleapis.com"
+}


### PR DESCRIPTION
Fix #585 
- Add deletion_policy to private service access sub-module
- Moved private service access sub-module to GA provider (TPG >=5.33)
- Fixed tests: Reduce number of cpu/memory to avoid running out of quota
- Fixed workflow service agent error in test
