### PR TITLE
fix: remove point_in_time_recorvery_enabled from MySQL instance as it…

### DIFF
--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -49,7 +49,7 @@ module "mysql-db" {
 | additional\_databases | A list of databases to be created in your cluster | <pre>list(object({<br>    name      = string<br>    charset   = string<br>    collation = string<br>  }))</pre> | `[]` | no |
 | additional\_users | A list of users to be created in your cluster. A random password would be set for the user if the `random_password` variable is set. | <pre>list(object({<br>    name            = string<br>    password        = string<br>    random_password = bool<br>    type            = string<br>    host            = string<br>  }))</pre> | `[]` | no |
 | availability\_type | The availability type for the master instance. Can be either `REGIONAL` or `null`. | `string` | `"REGIONAL"` | no |
-| backup\_configuration | The backup\_configuration settings subblock for the database setings | <pre>object({<br>    binary_log_enabled             = optional(bool, false)<br>    enabled                        = optional(bool, false)<br>    start_time                     = optional(string)<br>    location                       = optional(string)<br>    point_in_time_recovery_enabled = optional(bool, false)<br>    transaction_log_retention_days = optional(string)<br>    retained_backups               = optional(number)<br>    retention_unit                 = optional(string)<br>  })</pre> | `{}` | no |
+| backup\_configuration | The backup\_configuration settings subblock for the database setings | <pre>object({<br>    binary_log_enabled             = optional(bool, false)<br>    enabled                        = optional(bool, false)<br>    start_time                     = optional(string)<br>    location                       = optional(string)<br>    transaction_log_retention_days = optional(string)<br>    retained_backups               = optional(number)<br>    retention_unit                 = optional(string)<br>  })</pre> | `{}` | no |
 | connector\_enforcement | Enforce that clients use the connector library | `bool` | `false` | no |
 | create\_timeout | The optional timout that is applied to limit long database creates. | `string` | `"30m"` | no |
 | data\_cache\_enabled | Whether data cache is enabled for the instance. Defaults to false. Feature is only available for ENTERPRISE\_PLUS tier and supported database\_versions | `bool` | `false` | no |
@@ -58,7 +58,7 @@ module "mysql-db" {
 | database\_version | The database version to use | `string` | n/a | yes |
 | db\_charset | The charset for the default database | `string` | `""` | no |
 | db\_collation | The collation for the default database. Example: 'utf8\_general\_ci' | `string` | `""` | no |
-| db\_name | The name of the default database to create | `string` | `"default"` | no |
+| db\_name | The name of the default database to create. This should be unique per Cloud SQL instance. | `string` | `"default"` | no |
 | delete\_timeout | The optional timout that is applied to limit long database deletes. | `string` | `"30m"` | no |
 | deletion\_protection | Used to block Terraform from deleting a SQL Instance. | `bool` | `true` | no |
 | deletion\_protection\_enabled | Enables protection of an instance from accidental deletion across all surfaces (API, gcloud, Cloud Console and Terraform). | `bool` | `false` | no |

--- a/modules/mysql/metadata.display.yaml
+++ b/modules/mysql/metadata.display.yaml
@@ -57,7 +57,7 @@ spec:
             - type: ALTERNATE_TYPE_DC
               value:
                 enabled: true
-                point_in_time_recovery_enabled: true
+                binary_log_enabled: true
         connector_enforcement:
           name: connector_enforcement
           title: Connector Enforcement

--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -90,7 +90,7 @@ spec:
         varType: bool
         defaultValue: true
       - name: db_name
-        description: The name of the default database to create
+        description: The name of the default database to create. This should be unique per Cloud SQL instance.
         varType: string
         defaultValue: default
       - name: enable_default_user
@@ -263,7 +263,6 @@ spec:
               enabled                        = optional(bool, false)
               start_time                     = optional(string)
               location                       = optional(string)
-              point_in_time_recovery_enabled = optional(bool, false)
               transaction_log_retention_days = optional(string)
               retained_backups               = optional(number)
               retention_unit                 = optional(string)

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -56,7 +56,7 @@ variable "enable_default_db" {
 }
 
 variable "db_name" {
-  description = "The name of the default database to create"
+  description = "The name of the default database to create. This should be unique per Cloud SQL instance."
   type        = string
   default     = "default"
 }
@@ -295,7 +295,6 @@ variable "backup_configuration" {
     enabled                        = optional(bool, false)
     start_time                     = optional(string)
     location                       = optional(string)
-    point_in_time_recovery_enabled = optional(bool, false)
     transaction_log_retention_days = optional(string)
     retained_backups               = optional(number)
     retention_unit                 = optional(string)

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -130,7 +130,7 @@ module "pg" {
 | database\_version | The database version to use | `string` | n/a | yes |
 | db\_charset | The charset for the default database | `string` | `""` | no |
 | db\_collation | The collation for the default database. Example: 'en\_US.UTF8' | `string` | `""` | no |
-| db\_name | The name of the default database to create | `string` | `"default"` | no |
+| db\_name | The name of the default database to create. This should be unique per Cloud SQL instance. | `string` | `"default"` | no |
 | delete\_timeout | The optional timout that is applied to limit long database deletes. | `string` | `"30m"` | no |
 | deletion\_protection | Used to block Terraform from deleting a SQL Instance. | `bool` | `true` | no |
 | deletion\_protection\_enabled | Enables protection of an Cloud SQL instance from accidental deletion across all surfaces (API, gcloud, Cloud Console and Terraform). | `bool` | `false` | no |

--- a/modules/postgresql/metadata.yaml
+++ b/modules/postgresql/metadata.yaml
@@ -90,7 +90,7 @@ spec:
         varType: bool
         defaultValue: true
       - name: db_name
-        description: The name of the default database to create
+        description: The name of the default database to create. This should be unique per Cloud SQL instance.
         varType: string
         defaultValue: default
       - name: enable_default_user

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -60,7 +60,7 @@ variable "enable_default_db" {
 }
 
 variable "db_name" {
-  description = "The name of the default database to create"
+  description = "The name of the default database to create. This should be unique per Cloud SQL instance."
   type        = string
   default     = "default"
 }


### PR DESCRIPTION
… is not supported

Below is the error which is thrown when we create a MySQL instance with `point_in_time_recovery_enabled`,

`Error: point_in_time_recovery_enabled is only available for the following [POSTGRES SQLSERVER]. You may want to consider using binary_log_enabled instead and remove point_in_time_recovery_enabled (removing point_in_time_recovery_enabled and adding binary_log_enabled will enable pitr for MYSQL)`