### PR TITLE
feat: Add variables "enable_default_db", "enable_default_user" to module "safer_mysql"

### DIFF
--- a/modules/safer_mysql/README.md
+++ b/modules/safer_mysql/README.md
@@ -261,6 +261,8 @@ module "safer-mysql-db" {
 | disk\_size | The disk size for the master instance | `number` | `10` | no |
 | disk\_type | The disk type for the master instance. | `string` | `"PD_SSD"` | no |
 | edition | The edition of the instance, can be ENTERPRISE or ENTERPRISE\_PLUS. | `string` | `null` | no |
+| enable\_default\_db | Enable or disable the creation of the default database | `bool` | `true` | no |
+| enable\_default\_user | Enable or disable the creation of the default user | `bool` | `true` | no |
 | encryption\_key\_name | The full path to the encryption key used for the CMEK disk encryption | `string` | `null` | no |
 | follow\_gae\_application | A Google App Engine application whose zone to remain in. Must be in the same region as this instance. | `string` | `null` | no |
 | iam\_users | A list of IAM users to be created in your CloudSQL instance. iam.users.type can be CLOUD\_IAM\_USER, CLOUD\_IAM\_SERVICE\_ACCOUNT, CLOUD\_IAM\_GROUP and is required for type CLOUD\_IAM\_GROUP (IAM groups) | <pre>list(object({<br>    id    = string,<br>    email = string,<br>    type  = optional(string)<br>  }))</pre> | `[]` | no |

--- a/modules/safer_mysql/main.tf
+++ b/modules/safer_mysql/main.tf
@@ -60,11 +60,13 @@ module "safer_mysql" {
     allocated_ip_range  = var.allocated_ip_range
   }
 
-  db_name      = var.db_name
-  db_charset   = var.db_charset
-  db_collation = var.db_collation
+  enable_default_db = var.enable_default_db
+  db_name           = var.db_name
+  db_charset        = var.db_charset
+  db_collation      = var.db_collation
 
   additional_databases = var.additional_databases
+  enable_default_user  = var.enable_default_user
   user_name            = var.user_name
 
   // All MySQL users can connect only via the Cloud SQL Proxy.

--- a/modules/safer_mysql/variables.tf
+++ b/modules/safer_mysql/variables.tf
@@ -258,6 +258,12 @@ variable "read_replicas" {
   default = []
 }
 
+variable "enable_default_db" {
+  description = "Enable or disable the creation of the default database"
+  type        = bool
+  default     = true
+}
+
 variable "db_name" {
   description = "The name of the default database to create"
   type        = string
@@ -284,6 +290,12 @@ variable "additional_databases" {
     collation = string
   }))
   default = []
+}
+
+variable "enable_default_user" {
+  description = "Enable or disable the creation of the default user"
+  type        = bool
+  default     = true
 }
 
 variable "user_name" {


### PR DESCRIPTION
Those variables are currently not supported by the module `safer_mysql`, but by the module `mysql` which is used under the hood.

This PR adds both variables and hands them over to the module `mysql`.