### PR TITLE
feat: add setting enable_dataplex_integration

### DIFF
--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -55,6 +55,7 @@ module "mssql" {
 | disk\_size | The disk size for the Cloud SQL instance. | `number` | `10` | no |
 | disk\_type | The disk type for the Cloud SQL instance. | `string` | `"PD_SSD"` | no |
 | edition | The edition of the instance, can be ENTERPRISE or ENTERPRISE\_PLUS. | `string` | `null` | no |
+| enable\_dataplex\_integration | Enable database Dataplex integration | `bool` | `false` | no |
 | enable\_default\_db | Enable or disable the creation of the default database | `bool` | `true` | no |
 | enable\_default\_user | Enable or disable the creation of the default user | `bool` | `true` | no |
 | encryption\_key\_name | The full path to the encryption key used for the CMEK disk encryption | `string` | `null` | no |

--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -62,6 +62,7 @@ resource "google_sql_database_instance" "default" {
     availability_type           = var.availability_type
     deletion_protection_enabled = var.deletion_protection_enabled
     connector_enforcement       = local.connector_enforcement
+    enable_dataplex_integration = var.enable_dataplex_integration
 
     dynamic "backup_configuration" {
       for_each = !local.is_secondary_instance && var.backup_configuration.enabled ? [var.backup_configuration] : []

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -360,3 +360,9 @@ variable "enable_default_user" {
   type        = bool
   default     = true
 }
+
+variable "enable_dataplex_integration" {
+  description = "Enable database Dataplex integration"
+  type        = bool
+  default     = false
+}

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -68,6 +68,7 @@ module "mysql-db" {
 | disk\_size | The disk size (in GB) for the master instance | `number` | `10` | no |
 | disk\_type | The disk type for the master instance. | `string` | `"PD_SSD"` | no |
 | edition | The edition of the instance, can be ENTERPRISE or ENTERPRISE\_PLUS. | `string` | `null` | no |
+| enable\_dataplex\_integration | Enable database Dataplex integration | `bool` | `false` | no |
 | enable\_default\_db | Enable or disable the creation of the default database | `bool` | `true` | no |
 | enable\_default\_user | Enable or disable the creation of the default user | `bool` | `true` | no |
 | enable\_google\_ml\_integration | Enable database ML integration | `bool` | `false` | no |

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -72,6 +72,7 @@ resource "google_sql_database_instance" "default" {
     deletion_protection_enabled  = var.deletion_protection_enabled
     connector_enforcement        = local.connector_enforcement
     enable_google_ml_integration = var.enable_google_ml_integration
+    enable_dataplex_integration  = var.enable_dataplex_integration
 
     dynamic "backup_configuration" {
       for_each = [var.backup_configuration]

--- a/modules/mysql/metadata.display.yaml
+++ b/modules/mysql/metadata.display.yaml
@@ -162,6 +162,9 @@ spec:
         enable_google_ml_integration:
           name: enable_google_ml_integration
           title: Enable Google Ml Integration
+        enable_dataplex_integration:
+          name: enable_dataplex_integration
+          title: Enable Dataplex Integration
         enable_random_password_special:
           name: enable_random_password_special
           title: Enable Random Password Special

--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -406,6 +406,10 @@ spec:
         description: Enable database ML integration
         varType: bool
         defaultValue: false
+      - name: enable_dataplex_integration
+        description: Enable database Dataplex integration
+        varType: bool
+        defaultValue: false
       - name: database_integration_roles
         description: The roles required by default database instance service account for integration with GCP services
         varType: list(string)

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -462,6 +462,12 @@ variable "enable_google_ml_integration" {
   default     = false
 }
 
+variable "enable_dataplex_integration" {
+  description = "Enable database Dataplex integration"
+  type        = bool
+  default     = false
+}
+
 variable "database_integration_roles" {
   description = "The roles required by default database instance service account for integration with GCP services"
   type        = list(string)

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -140,6 +140,7 @@ module "pg" {
 | disk\_size | The disk size (in GB) for the Cloud SQL instance. | `number` | `10` | no |
 | disk\_type | The disk type for the Cloud SQL instance. | `string` | `"PD_SSD"` | no |
 | edition | The edition of the Cloud SQL instance, can be ENTERPRISE or ENTERPRISE\_PLUS. | `string` | `null` | no |
+| enable\_dataplex\_integration | Enable database Dataplex integration | `bool` | `false` | no |
 | enable\_default\_db | Enable or disable the creation of the default database | `bool` | `true` | no |
 | enable\_default\_user | Enable or disable the creation of the default user | `bool` | `true` | no |
 | enable\_google\_ml\_integration | Enable database ML integration | `bool` | `false` | no |

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -75,6 +75,7 @@ resource "google_sql_database_instance" "default" {
     deletion_protection_enabled  = var.deletion_protection_enabled
     connector_enforcement        = local.connector_enforcement
     enable_google_ml_integration = var.enable_google_ml_integration
+    enable_dataplex_integration  = var.enable_dataplex_integration
 
     dynamic "backup_configuration" {
       for_each = local.is_secondary_instance ? [] : [var.backup_configuration]

--- a/modules/postgresql/metadata.display.yaml
+++ b/modules/postgresql/metadata.display.yaml
@@ -170,6 +170,9 @@ spec:
         enable_google_ml_integration:
           name: enable_google_ml_integration
           title: Enable Google Ml Integration
+        enable_dataplex_integration:
+          name: enable_dataplex_integration
+          title: Enable Dataplex Integration
         enable_random_password_special:
           name: enable_random_password_special
           title: Enable Random Password Special

--- a/modules/postgresql/metadata.yaml
+++ b/modules/postgresql/metadata.yaml
@@ -396,6 +396,10 @@ spec:
         description: Enable database ML integration
         varType: bool
         defaultValue: false
+      - name: enable_dataplex_integration
+        description: Enable database Dataplex integration
+        varType: bool
+        defaultValue: false
       - name: database_integration_roles
         description: The roles required by default database instance service account for integration with GCP services
         varType: list(string)

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -451,6 +451,12 @@ variable "enable_google_ml_integration" {
   default     = false
 }
 
+variable "enable_dataplex_integration" {
+  description = "Enable database Dataplex integration"
+  type        = bool
+  default     = false
+}
+
 variable "database_integration_roles" {
   description = "The roles required by default database instance service account for integration with GCP services"
   type        = list(string)


### PR DESCRIPTION
PR adds:
- Add `enable_dataplex_integration` setting for `mssql`, `mysql` and `postgresql` database modules. instance.https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#enable_dataplex_integration-1 

Official Cloudsql <-> Dataplex integration docs https://cloud.google.com/sql/docs/postgres/dataplex-catalog-integration