### PR TITLE
Fix: Postgres read-replica "psc_enabled" change never set

### DIFF
--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -64,10 +64,10 @@ resource "google_sql_database_instance" "replicas" {
           }
         }
         dynamic "psc_config" {
-          for_each = ip_configuration.value.psc_enabled ? ["psc_enabled"] : []
+          for_each = ip_configuration.value.psc_enabled ? ["psc_enabled"] : ["psc_disabled"]
           content {
             psc_enabled               = ip_configuration.value.psc_enabled
-            allowed_consumer_projects = ip_configuration.value.psc_allowed_consumer_projects
+            allowed_consumer_projects = ip_configuration.value.psc_enabled ? ip_configuration.value.psc_allowed_consumer_projects : []
           }
         }
       }


### PR DESCRIPTION
The `psc_config` dynamic block in resource `google_sql_database_instance.replicas` keeps getting removed by the planner while the defaults are always present. 
This pull request keeps the block with default values when PSC is disabled inside the replica.
No functional changes. Keeps the plan tidy, that's all

<img width="554" alt="Screenshot 2025-04-09 at 11 57 53 AM" src="https://github.com/user-attachments/assets/5a502040-533c-4c04-bf36-436197072b54" />
