### PR TITLE
fix: Disable SQL instance data_cache when data_cache_enabled variable is false

### DIFF
--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -83,7 +83,7 @@ resource "google_sql_database_instance" "default" {
       }
     }
     dynamic "data_cache_config" {
-      for_each = var.edition == "ENTERPRISE_PLUS" && var.data_cache_enabled ? ["cache_enabled"] : []
+      for_each = var.edition == "ENTERPRISE_PLUS" ? ["cache_enabled"] : []
       content {
         data_cache_enabled = var.data_cache_enabled
       }

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -105,7 +105,7 @@ resource "google_sql_database_instance" "default" {
       }
     }
     dynamic "data_cache_config" {
-      for_each = var.edition == "ENTERPRISE_PLUS" && var.data_cache_enabled ? ["cache_enabled"] : []
+      for_each = var.edition == "ENTERPRISE_PLUS" ? ["cache_enabled"] : []
       content {
         data_cache_enabled = var.data_cache_enabled
       }

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -98,7 +98,7 @@ resource "google_sql_database_instance" "default" {
       }
     }
     dynamic "data_cache_config" {
-      for_each = var.edition == "ENTERPRISE_PLUS" && var.data_cache_enabled ? ["cache_enabled"] : []
+      for_each = var.edition == "ENTERPRISE_PLUS" ? ["cache_enabled"] : []
       content {
         data_cache_enabled = var.data_cache_enabled
       }


### PR DESCRIPTION
When var.data_cache_enabled is set to false, the dynamic block data_cache_config is ignored. Exemple with [mysql module](https://github.com/terraform-google-modules/terraform-google-sql-db/blob/main/modules/mysql/main.tf#L107):

```
for_each = var.edition == "ENTERPRISE_PLUS" && var.data_cache_enabled ? ["cache_enabled"] : []
```

Due to this, the default value on GCP Cloud SQL, which is `true`, is applied.

Example:

- Create Cloud SQL instance:

```
gcloud sql instances create mysql-testing-instance --region europe-west1 --tier 'db-perf-optimized-N-2' --project-id sbx --database-version 'MYSQL_8_0' --edition ENTERPRISE_PLUS
```

- Check the data cache value:

```
gcloud sql instances describe mysql-testing-instance --project sbx | grep -A 2 dataCacheConfig

  dataCacheConfig:
    dataCacheEnabled: true
  dataDiskSizeGb: '10'
```
