### PR TITLE
chore: update current version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,22 @@ If you find incompatibilities using Terraform `>=1.13`, please open an issue.
 
 ## Upgrading
 
-The current version is 25.X. The following guides are available to assist with upgrades:
+The current version is 26.X. The following guides are available to assist with upgrades:
 
 - [1.X -> 2.0](./docs/upgrading_to_sql_db_2.0.0.md)
 - [2.X -> 3.0](./docs/upgrading_to_sql_db_3.0.0.md)
 - [3.X -> 4.0](./docs/upgrading_to_sql_db_4.0.0.md)
 - [10.X -> 11.0](./docs/upgrading_to_sql_db_11.0.0.md)
 - [11.X -> 12.0](./docs/upgrading_to_sql_db_12.0.0.md)
+- [13.X -> 14.0](./docs/upgrading_to_sql_db_14.0.0.md)
+- [14.X -> 15.0](./docs/upgrading_to_sql_db_15.0.0.md)
+- [16.X -> 17.0](./docs/upgrading_to_sql_db_17.0.0.md)
 - [19.X -> 20.0](./docs/upgrading_to_sql_db_20.0.0.md)
 - [20.X -> 21.0](./docs/upgrading_to_sql_db_21.0.md)
 - [21.X -> 22.0](./docs/upgrading_to_sql_db_22.0.md)
 - [22.X -> 23.0](./docs/upgrading_to_sql_db_23.0.md)
 - [23.X -> 24.0](./docs/upgrading_to_sql_db_24.0.md)
+- [25.X -> 26.0](./docs/upgrading_to_sql_db_26.0.md)
 
 ## Root module
 


### PR DESCRIPTION
Current version stayed on 20.X instead of being updated