### PR TITLE
fix: truncate service account display_name in backup module

### DIFF
--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -33,7 +33,7 @@ locals {
 resource "google_service_account" "sql_backup_serviceaccount" {
   count        = local.create_service_account ? 1 : 0
   account_id   = trimsuffix(substr("backup-${var.sql_instance}", 0, 28), "-")
-  display_name = "Managed by Terraform - Service account for backup of SQL Instance ${var.sql_instance}"
+  display_name = substr("Managed by Terraform - Service account for backup of SQL Instance ${var.sql_instance}", 0, 100)
   project      = var.project_id
 }
 


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-google-sql-db/issues/733

My database name is 35 characters long. The `Managed by Terraform - Service account for backup of SQL Instance ` string is 66 characters long. In total this makes 101 characters, which fails the validation check to create the service account:

```
Error: Error creating service account: googleapi: Error 400: The display_name length (101) is longer than the maximum allowed length 100., badRequest
  with module.cloudsql_backup[0].google_service_account.sql_backup_serviceaccount[0],
  on .terraform/modules/cloudsql_backup/modules/backup/main.tf line 33, in resource "google_service_account" "sql_backup_serviceaccount":
  33: resource "google_service_account" "sql_backup_serviceaccount" {
```

This change will truncate the display_name if it exceeds 100 characters.