### PR TITLE
feat: per module requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25.4
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25.4
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.22
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
@@ -80,7 +80,7 @@ docker_generate_docs:
 		-e ENABLE_BPMETADATA \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
-		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs'
+		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs --per-module-requirements'
 
 # Alias for backwards compatibility
 .PHONY: generate_docs

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -75,26 +61,13 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudkms.admin
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
-          - roles/cloudscheduler.admin
+          - roles/resourcemanager.projectIamAdmin
+          - roles/serviceusage.serviceUsageAdmin
           - roles/cloudsql.admin
-          - roles/compute.admin
-          - roles/compute.networkAdmin
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
-          - roles/monitoring.editor
-          - roles/resourcemanager.projectIamAdmin
-          - roles/storage.admin
-          - roles/workflows.admin
     services:
-      - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com
-      - cloudscheduler.googleapis.com
-      - compute.googleapis.com
       - iam.googleapis.com
-      - monitoring.googleapis.com
-      - servicenetworking.googleapis.com
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com
-      - workflows.googleapis.com

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2025 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -75,11 +61,11 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/iam.serviceAccountUser
           - roles/resourcemanager.projectIamAdmin
           - roles/serviceusage.serviceUsageAdmin
           - roles/cloudsql.admin
           - roles/iam.serviceAccountAdmin
-          - roles/iam.serviceAccountUser
     services:
       - cloudresourcemanager.googleapis.com
       - iam.googleapis.com

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -75,11 +75,11 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/cloudsql.admin
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
           - roles/resourcemanager.projectIamAdmin
           - roles/serviceusage.serviceUsageAdmin
-          - roles/cloudsql.admin
     services:
       - cloudresourcemanager.googleapis.com
       - iam.googleapis.com

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -75,11 +75,11 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
           - roles/resourcemanager.projectIamAdmin
           - roles/serviceusage.serviceUsageAdmin
           - roles/cloudsql.admin
-          - roles/iam.serviceAccountAdmin
     services:
       - cloudresourcemanager.googleapis.com
       - iam.googleapis.com

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -75,11 +75,11 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
           - roles/resourcemanager.projectIamAdmin
           - roles/serviceusage.serviceUsageAdmin
           - roles/cloudsql.admin
+          - roles/iam.serviceAccountAdmin
     services:
       - cloudresourcemanager.googleapis.com
       - iam.googleapis.com

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -61,11 +75,11 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
           - roles/resourcemanager.projectIamAdmin
           - roles/serviceusage.serviceUsageAdmin
           - roles/cloudsql.admin
-          - roles/iam.serviceAccountAdmin
     services:
       - cloudresourcemanager.googleapis.com
       - iam.googleapis.com

--- a/modules/backup/metadata.yaml
+++ b/modules/backup/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/modules/backup/metadata.yaml
+++ b/modules/backup/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -61,10 +47,21 @@ spec:
         location: examples/private_service_access
   interfaces:
     variables:
-      - name: backup_monitoring_frequency
-        description: Timeframe in which there should be at least one successfull backup
+      - name: region
+        description: The region where to run the workflow
         varType: string
-        defaultValue: 1d
+        defaultValue: us-central1
+      - name: service_account
+        description: The service account to use for running the workflow and triggering the workflow by Cloud Scheduler - If empty or null a service account will be created. If you have provided a service account you need to grant the Cloud SQL Admin and the Workflows Invoker role to that
+        varType: string
+      - name: project_id
+        description: The project ID
+        varType: string
+        required: true
+      - name: sql_instance
+        description: The name of the SQL instance to backup
+        varType: string
+        required: true
       - name: backup_retention_time
         description: The number of days backups should be kept
         varType: number
@@ -73,69 +70,88 @@ spec:
         description: The max amount of backups to list when fetching internal backup runs for the instance. This number must be larger then the amount of backups you wish to keep. E.g. for a daily backup schedule and a backup_retention_time of 30 days, you'd need to set this to at least 31 for old backups to get deleted.
         varType: number
         defaultValue: 31
+      - name: scheduler_timezone
+        description: The Timezone in which the Scheduler Jobs are triggered
+        varType: string
+        defaultValue: Etc/GMT
       - name: backup_schedule
         description: The cron schedule to execute the internal backup
         varType: string
         defaultValue: 45 2 * * *
-      - name: compress_export
-        description: Whether or not to compress the export when storing in the bucket; Only valid for MySQL and PostgreSQL
-        varType: bool
-        defaultValue: true
-      - name: connector_params_timeout
-        description: The end-to-end duration the connector call is allowed to run for before throwing a timeout exception. The default value is 1800 and this should be the maximum for connector methods that are not long-running operations. Otherwise, for long-running operations, the maximum timeout for a connector call is 31536000 seconds (one year).
-        varType: number
-        defaultValue: 1800
-      - name: create_notification_channel
-        description: If set to true it will create email notification channel
-        varType: bool
-        defaultValue: false
-      - name: deletion_protection
-        description: Whether Terraform will be prevented from destroying the workflow.
-        varType: bool
-        defaultValue: true
-      - name: enable_backup_monitoring
-        description: Whether to monitor backup workflows or not
-        varType: bool
-        defaultValue: false
-      - name: enable_connector_params
-        description: Whether to enable connector-specific parameters for Google Workflow SQL Export.
-        varType: bool
-        defaultValue: false
-      - name: enable_export_backup
-        description: Weather to create exports to GCS Buckets with this module
-        varType: bool
-        defaultValue: true
-      - name: enable_export_monitoring
-        description: Whether to monitor export workflows or not
-        varType: bool
-        defaultValue: false
+      - name: export_schedule
+        description: The cron schedule to execute the export to GCS
+        varType: string
+        defaultValue: 15 3 * * *
       - name: enable_internal_backup
         description: Wether to create internal backups with this module
+        varType: bool
+        defaultValue: true
+      - name: enable_export_backup
+        description: Weather to create exports to GCS Buckets with this module
         varType: bool
         defaultValue: true
       - name: export_databases
         description: The list of databases that should be exported - if is an empty set all databases will be exported
         varType: set(string)
         defaultValue: []
-      - name: export_monitoring_frequency
-        description: Timeframe in which there should be at least one successfull export
-        varType: string
-        defaultValue: 1d
-      - name: export_schedule
-        description: The cron schedule to execute the export to GCS
-        varType: string
-        defaultValue: 15 3 * * *
       - name: export_uri
         description: The bucket and path uri for exporting to GCS
         varType: string
         required: true
+      - name: compress_export
+        description: Whether or not to compress the export when storing in the bucket; Only valid for MySQL and PostgreSQL
+        varType: bool
+        defaultValue: true
+      - name: enable_connector_params
+        description: Whether to enable connector-specific parameters for Google Workflow SQL Export.
+        varType: bool
+        defaultValue: false
+      - name: connector_params_timeout
+        description: The end-to-end duration the connector call is allowed to run for before throwing a timeout exception. The default value is 1800 and this should be the maximum for connector methods that are not long-running operations. Otherwise, for long-running operations, the maximum timeout for a connector call is 31536000 seconds (one year).
+        varType: number
+        defaultValue: 1800
+      - name: unique_suffix
+        description: Unique suffix to add to scheduler jobs and workflows names.
+        varType: string
+        defaultValue: ""
       - name: log_db_name_to_export
         description: Whether or not to log database name in the export workflow
+        varType: bool
+        defaultValue: false
+      - name: use_sql_instance_replica_in_exporter
+        description: Whether or not to use replica instance on exporter workflow.
+        varType: bool
+        defaultValue: false
+      - name: sql_instance_replica
+        description: The name of the SQL instance replica to export
+        varType: string
+      - name: use_serverless_export
+        description: Whether to use serverless export for DB export
         varType: bool
         defaultValue: false
       - name: monitoring_email
         description: Email address to send alerts
         varType: string
+      - name: enable_backup_monitoring
+        description: Whether to monitor backup workflows or not
+        varType: bool
+        defaultValue: false
+      - name: backup_monitoring_frequency
+        description: Timeframe in which there should be at least one successfull backup
+        varType: string
+        defaultValue: 1d
+      - name: enable_export_monitoring
+        description: Whether to monitor export workflows or not
+        varType: bool
+        defaultValue: false
+      - name: export_monitoring_frequency
+        description: Timeframe in which there should be at least one successfull export
+        varType: string
+        defaultValue: 1d
+      - name: create_notification_channel
+        description: If set to true it will create email notification channel
+        varType: bool
+        defaultValue: false
       - name: notification_channel_name
         description: Name of the email notification channel to be created. Only needed when create_notification_channel is set to true.
         varType: string
@@ -144,40 +160,10 @@ spec:
         description: List of existing notification channels to send alerts to
         varType: list(string)
         defaultValue: []
-      - name: project_id
-        description: The project ID
-        varType: string
-        required: true
-      - name: region
-        description: The region where to run the workflow
-        varType: string
-        defaultValue: us-central1
-      - name: scheduler_timezone
-        description: The Timezone in which the Scheduler Jobs are triggered
-        varType: string
-        defaultValue: Etc/GMT
-      - name: service_account
-        description: The service account to use for running the workflow and triggering the workflow by Cloud Scheduler - If empty or null a service account will be created. If you have provided a service account you need to grant the Cloud SQL Admin and the Workflows Invoker role to that
-        varType: string
-      - name: sql_instance
-        description: The name of the SQL instance to backup
-        varType: string
-        required: true
-      - name: sql_instance_replica
-        description: The name of the SQL instance replica to export
-        varType: string
-      - name: unique_suffix
-        description: Unique suffix to add to scheduler jobs and workflows names.
-        varType: string
-        defaultValue: ""
-      - name: use_serverless_export
-        description: Whether to use serverless export for DB export
+      - name: deletion_protection
+        description: Whether Terraform will be prevented from destroying the workflow.
         varType: bool
-        defaultValue: false
-      - name: use_sql_instance_replica_in_exporter
-        description: Whether or not to use replica instance on exporter workflow.
-        varType: bool
-        defaultValue: false
+        defaultValue: true
     outputs:
       - name: backup_workflow_name
         description: The name for internal backup workflow
@@ -191,26 +177,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudkms.admin
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
-          - roles/cloudscheduler.admin
-          - roles/cloudsql.admin
-          - roles/compute.admin
-          - roles/compute.networkAdmin
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
-          - roles/monitoring.editor
-          - roles/resourcemanager.projectIamAdmin
-          - roles/storage.admin
-          - roles/workflows.admin
+          - roles/logging.logWriter
+          - roles/cloudsql.admin
     services:
-      - cloudkms.googleapis.com
-      - cloudresourcemanager.googleapis.com
-      - cloudscheduler.googleapis.com
-      - compute.googleapis.com
-      - iam.googleapis.com
-      - monitoring.googleapis.com
-      - servicenetworking.googleapis.com
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com
-      - workflows.googleapis.com
+    providerVersions:
+      - source: hashicorp/google
+        version: ">= 6.11.0, < 7"

--- a/modules/backup/metadata.yaml
+++ b/modules/backup/metadata.yaml
@@ -191,9 +191,9 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/iam.serviceAccountUser
           - roles/logging.logWriter
           - roles/cloudsql.admin
+          - roles/iam.serviceAccountUser
     services:
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com

--- a/modules/backup/metadata.yaml
+++ b/modules/backup/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2025 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -191,9 +177,9 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/logging.logWriter
           - roles/cloudsql.admin
           - roles/iam.serviceAccountUser
+          - roles/logging.logWriter
     services:
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com

--- a/modules/backup/metadata.yaml
+++ b/modules/backup/metadata.yaml
@@ -191,9 +191,9 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudsql.admin
           - roles/iam.serviceAccountUser
           - roles/logging.logWriter
+          - roles/cloudsql.admin
     services:
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com

--- a/modules/backup/metadata.yaml
+++ b/modules/backup/metadata.yaml
@@ -191,9 +191,9 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/logging.logWriter
           - roles/cloudsql.admin
           - roles/iam.serviceAccountUser
+          - roles/logging.logWriter
     services:
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com

--- a/modules/mssql/metadata.yaml
+++ b/modules/mssql/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/modules/mssql/metadata.yaml
+++ b/modules/mssql/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2025 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/modules/mssql/metadata.yaml
+++ b/modules/mssql/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -81,6 +67,9 @@ spec:
         description: Sets random suffix at the end of the Cloud SQL resource name
         varType: bool
         defaultValue: false
+      - name: maintenance_version
+        description: The current software version on the instance. This attribute can not be set during creation. Refer to available_maintenance_versions attribute to see what maintenance_version are available for upgrade. When this attribute gets updated, it will cause an instance restart. Setting a maintenance_version value that is older than the current one on the instance will be ignored
+        varType: string
       - name: database_version
         description: "The database version to use: SQLSERVER_2017_STANDARD, SQLSERVER_2017_ENTERPRISE, SQLSERVER_2017_EXPRESS, or SQLSERVER_2017_WEB"
         varType: string
@@ -298,6 +287,19 @@ spec:
         description: Enable or disable the creation of the default user
         varType: bool
         defaultValue: true
+      - name: enable_dataplex_integration
+        description: Enable database Dataplex integration
+        varType: bool
+        defaultValue: false
+      - name: insights_config
+        description: The insights_config settings for the database.
+        varType: |-
+          object({
+              query_plans_per_minute  = optional(number, 5)
+              query_string_length     = optional(number, 1024)
+              record_application_tags = optional(bool, false)
+              record_client_address   = optional(bool, false)
+            })
     outputs:
       - name: additional_users
         description: List of maps of additional users and passwords
@@ -547,29 +549,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudkms.admin
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
-          - roles/cloudscheduler.admin
-          - roles/cloudsql.admin
-          - roles/compute.admin
-          - roles/compute.networkAdmin
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
-          - roles/monitoring.editor
-          - roles/resourcemanager.projectIamAdmin
-          - roles/storage.admin
-          - roles/workflows.admin
+          - roles/logging.logWriter
+          - roles/cloudsql.admin
     services:
-      - cloudkms.googleapis.com
-      - cloudresourcemanager.googleapis.com
-      - cloudscheduler.googleapis.com
-      - compute.googleapis.com
-      - iam.googleapis.com
-      - monitoring.googleapis.com
-      - servicenetworking.googleapis.com
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com
-      - workflows.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 5.12, < 7"

--- a/modules/mssql/metadata.yaml
+++ b/modules/mssql/metadata.yaml
@@ -563,10 +563,15 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/cloudsql.admin
           - roles/iam.serviceAccountUser
           - roles/logging.logWriter
-          - roles/cloudsql.admin
     services:
+      - cloudkms.googleapis.com
+      - cloudresourcemanager.googleapis.com
+      - compute.googleapis.com
+      - iam.googleapis.com
+      - monitoring.googleapis.com
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com
     providerVersions:

--- a/modules/mssql/metadata.yaml
+++ b/modules/mssql/metadata.yaml
@@ -563,9 +563,9 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/logging.logWriter
           - roles/cloudsql.admin
           - roles/iam.serviceAccountUser
+          - roles/logging.logWriter
     services:
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com

--- a/modules/mssql/metadata.yaml
+++ b/modules/mssql/metadata.yaml
@@ -563,9 +563,9 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/logging.logWriter
           - roles/cloudsql.admin
           - roles/iam.serviceAccountUser
-          - roles/logging.logWriter
     services:
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com

--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2025 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -279,6 +265,10 @@ spec:
               retention_unit                 = optional(string)
             })
         defaultValue: {}
+      - name: retain_backups_on_delete
+        description: When this parameter is set to true, Cloud SQL retains backups of the instance even after the instance is deleted. The ON_DEMAND backup will be retained until customer deletes the backup or the project. The AUTOMATED backup will be retained based on the backups retention setting.
+        varType: bool
+        defaultValue: false
       - name: insights_config
         description: The insights_config settings for the database.
         varType: |-
@@ -914,35 +904,17 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudkms.admin
-          - roles/cloudkms.autokeyAdmin
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
-          - roles/cloudscheduler.admin
           - roles/cloudsql.admin
-          - roles/compute.admin
-          - roles/compute.networkAdmin
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
-          - roles/monitoring.editor
-          - roles/resourcemanager.projectIamAdmin
-          - roles/storage.admin
-          - roles/workflows.admin
+          - roles/logging.logWriter
     services:
-      - cloudkms.googleapis.com
-      - cloudresourcemanager.googleapis.com
-      - cloudscheduler.googleapis.com
-      - compute.googleapis.com
-      - iam.googleapis.com
-      - monitoring.googleapis.com
-      - servicenetworking.googleapis.com
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com
-      - workflows.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 6.1, < 7"
+        version: ">= 6.31, < 7"
       - source: hashicorp/google-beta
-        version: ">= 6.1, < 7"
+        version: ">= 6.31, < 7"
       - source: hashicorp/null
         version: ~> 3.1
       - source: hashicorp/random

--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -918,18 +918,19 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.networkAdmin
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
-          - roles/logging.logWriter
           - roles/cloudsql.admin
           - roles/resourcemanager.projectIamAdmin
           - roles/iam.serviceAccountUser
+          - roles/compute.networkAdmin
+          - roles/cloudkms.cryptoKeyEncrypterDecrypter
+          - roles/logging.logWriter
     services:
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com
       - compute.googleapis.com
       - iam.googleapis.com
       - monitoring.googleapis.com
+      - servicenetworking.googleapis.com
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com
     providerVersions:

--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2025 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -918,13 +904,18 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
-          - roles/logging.logWriter
-          - roles/cloudsql.admin
           - roles/resourcemanager.projectIamAdmin
           - roles/iam.serviceAccountUser
           - roles/compute.networkAdmin
+          - roles/cloudkms.cryptoKeyEncrypterDecrypter
+          - roles/logging.logWriter
+          - roles/cloudsql.admin
     services:
+      - cloudkms.googleapis.com
+      - cloudresourcemanager.googleapis.com
+      - compute.googleapis.com
+      - iam.googleapis.com
+      - monitoring.googleapis.com
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com
     providerVersions:

--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -918,12 +918,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudsql.admin
-          - roles/resourcemanager.projectIamAdmin
-          - roles/iam.serviceAccountUser
           - roles/compute.networkAdmin
           - roles/cloudkms.cryptoKeyEncrypterDecrypter
           - roles/logging.logWriter
+          - roles/cloudsql.admin
+          - roles/resourcemanager.projectIamAdmin
+          - roles/iam.serviceAccountUser
     services:
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com

--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -904,12 +918,12 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/cloudsql.admin
           - roles/resourcemanager.projectIamAdmin
           - roles/iam.serviceAccountUser
           - roles/compute.networkAdmin
           - roles/cloudkms.cryptoKeyEncrypterDecrypter
           - roles/logging.logWriter
-          - roles/cloudsql.admin
     services:
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com

--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -918,9 +918,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudsql.admin
-          - roles/iam.serviceAccountUser
+          - roles/cloudkms.cryptoKeyEncrypterDecrypter
           - roles/logging.logWriter
+          - roles/cloudsql.admin
+          - roles/resourcemanager.projectIamAdmin
+          - roles/iam.serviceAccountUser
+          - roles/compute.networkAdmin
     services:
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com

--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -918,12 +918,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudsql.admin
-          - roles/resourcemanager.projectIamAdmin
           - roles/iam.serviceAccountUser
           - roles/compute.networkAdmin
           - roles/cloudkms.cryptoKeyEncrypterDecrypter
           - roles/logging.logWriter
+          - roles/cloudsql.admin
+          - roles/resourcemanager.projectIamAdmin
     services:
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com

--- a/modules/postgresql/metadata.yaml
+++ b/modules/postgresql/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/modules/postgresql/metadata.yaml
+++ b/modules/postgresql/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2025 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -279,6 +265,9 @@ spec:
               enable_private_path_for_google_cloud_services = optional(bool, false)
               psc_enabled                                   = optional(bool, false)
               psc_allowed_consumer_projects                 = optional(list(string), [])
+              server_ca_mode                                = optional(string)
+              server_ca_pool                                = optional(string)
+              custom_subject_alternative_names              = optional(list(string), [])
             })
         defaultValue: {}
         connections:
@@ -408,7 +397,18 @@ spec:
         varType: list(string)
         defaultValue: []
       - name: use_autokey
-        description: Enable the use of autokeys from Google Cloud KMS for CMEK. This requires autokey already configured in the project.
+        description: Enable the use of autokeys from Google Cloud KMS for CMEK. This requires autokey already configured in the project
+        varType: bool
+        defaultValue: false
+      - name: create_kms_key_handle
+        description: KeyHandles cannot be deleted from Google Cloud Platform. Destroying a Terraform-managed KeyHandle will remove it from state but will not delete the resource from the project. Set this to false if key handle already exists
+        varType: bool
+        defaultValue: true
+      - name: kms_key_handle_name
+        description: key handle name. If not provided module will use instance name as key handle name
+        varType: string
+      - name: retain_backups_on_delete
+        description: When this parameter is set to true, Cloud SQL retains backups of the instance even after the instance is deleted. The ON_DEMAND backup will be retained until customer deletes the backup or the project. The AUTOMATED backup will be retained based on the backups retention setting.
         varType: bool
         defaultValue: false
     outputs:
@@ -910,35 +910,17 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudkms.admin
-          - roles/cloudkms.autokeyAdmin
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
-          - roles/cloudscheduler.admin
           - roles/cloudsql.admin
-          - roles/compute.admin
-          - roles/compute.networkAdmin
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
-          - roles/monitoring.editor
-          - roles/resourcemanager.projectIamAdmin
-          - roles/storage.admin
-          - roles/workflows.admin
+          - roles/logging.logWriter
     services:
-      - cloudkms.googleapis.com
-      - cloudresourcemanager.googleapis.com
-      - cloudscheduler.googleapis.com
-      - compute.googleapis.com
-      - iam.googleapis.com
-      - monitoring.googleapis.com
-      - servicenetworking.googleapis.com
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com
-      - workflows.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 6.1, < 7"
+        version: ">= 6.31, < 7"
       - source: hashicorp/google-beta
-        version: ">= 6.1, < 7"
+        version: ">= 6.31, < 7"
       - source: hashicorp/null
         version: ~> 3.1
       - source: hashicorp/random

--- a/modules/postgresql/metadata.yaml
+++ b/modules/postgresql/metadata.yaml
@@ -924,21 +924,22 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/cloudkms.admin
+          - roles/logging.logWriter
           - roles/cloudsql.admin
+          - roles/storage.admin
           - roles/resourcemanager.projectIamAdmin
           - roles/iam.serviceAccountUser
           - roles/compute.networkAdmin
-          - roles/cloudkms.admin
           - roles/cloudkms.autokeyAdmin
-          - roles/storage.admin
           - roles/cloudkms.cryptoKeyEncrypterDecrypter
-          - roles/logging.logWriter
     services:
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com
       - compute.googleapis.com
       - iam.googleapis.com
       - monitoring.googleapis.com
+      - servicenetworking.googleapis.com
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com
     providerVersions:

--- a/modules/postgresql/metadata.yaml
+++ b/modules/postgresql/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2025 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -924,12 +910,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.networkAdmin
-          - roles/cloudkms.admin
-          - roles/logging.logWriter
           - roles/cloudsql.admin
           - roles/resourcemanager.projectIamAdmin
           - roles/iam.serviceAccountUser
+          - roles/compute.networkAdmin
+          - roles/cloudkms.admin
+          - roles/logging.logWriter
     services:
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com

--- a/modules/postgresql/metadata.yaml
+++ b/modules/postgresql/metadata.yaml
@@ -924,15 +924,15 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/resourcemanager.projectIamAdmin
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
-          - roles/logging.logWriter
           - roles/cloudsql.admin
-          - roles/storage.admin
+          - roles/resourcemanager.projectIamAdmin
           - roles/iam.serviceAccountUser
           - roles/compute.networkAdmin
           - roles/cloudkms.admin
           - roles/cloudkms.autokeyAdmin
+          - roles/storage.admin
+          - roles/cloudkms.cryptoKeyEncrypterDecrypter
+          - roles/logging.logWriter
     services:
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com

--- a/modules/postgresql/metadata.yaml
+++ b/modules/postgresql/metadata.yaml
@@ -924,12 +924,15 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudsql.admin
           - roles/resourcemanager.projectIamAdmin
+          - roles/cloudkms.cryptoKeyEncrypterDecrypter
+          - roles/logging.logWriter
+          - roles/cloudsql.admin
+          - roles/storage.admin
           - roles/iam.serviceAccountUser
           - roles/compute.networkAdmin
           - roles/cloudkms.admin
-          - roles/logging.logWriter
+          - roles/cloudkms.autokeyAdmin
     services:
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com

--- a/modules/postgresql/metadata.yaml
+++ b/modules/postgresql/metadata.yaml
@@ -924,10 +924,18 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudsql.admin
-          - roles/iam.serviceAccountUser
+          - roles/compute.networkAdmin
+          - roles/cloudkms.admin
           - roles/logging.logWriter
+          - roles/cloudsql.admin
+          - roles/resourcemanager.projectIamAdmin
+          - roles/iam.serviceAccountUser
     services:
+      - cloudkms.googleapis.com
+      - cloudresourcemanager.googleapis.com
+      - compute.googleapis.com
+      - iam.googleapis.com
+      - monitoring.googleapis.com
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com
     providerVersions:

--- a/modules/private_service_access/metadata.yaml
+++ b/modules/private_service_access/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/modules/private_service_access/metadata.yaml
+++ b/modules/private_service_access/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2025 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/modules/private_service_access/metadata.yaml
+++ b/modules/private_service_access/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -90,8 +104,8 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/iam.serviceAccountUser
           - roles/servicenetworking.networksAdmin
+          - roles/iam.serviceAccountUser
     services:
       - servicenetworking.googleapis.com
       - serviceusage.googleapis.com

--- a/modules/private_service_access/metadata.yaml
+++ b/modules/private_service_access/metadata.yaml
@@ -104,8 +104,8 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/servicenetworking.networksAdmin
           - roles/iam.serviceAccountUser
+          - roles/servicenetworking.networksAdmin
     services:
       - servicenetworking.googleapis.com
       - serviceusage.googleapis.com

--- a/modules/private_service_access/metadata.yaml
+++ b/modules/private_service_access/metadata.yaml
@@ -104,8 +104,8 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/iam.serviceAccountUser
           - roles/servicenetworking.networksAdmin
+          - roles/iam.serviceAccountUser
     services:
       - servicenetworking.googleapis.com
       - serviceusage.googleapis.com

--- a/modules/private_service_access/metadata.yaml
+++ b/modules/private_service_access/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -28,7 +14,7 @@ spec:
     version: 26.1.1
     actuationTool:
       flavor: Terraform
-      version: ">= 0.13"
+      version: ">= 1.3"
     description: {}
   content:
     examples:
@@ -62,29 +48,6 @@ spec:
         location: examples/private_service_access
   interfaces:
     variables:
-      - name: address
-        description: First IP address of the IP range to allocate to CLoud SQL instances and other Private Service Access services. If not set, GCP will pick a valid one for you.
-        varType: string
-        defaultValue: ""
-      - name: deletion_policy
-        description: The deletion policy for the service networking connection. Setting to ABANDON allows the resource to be abandoned rather than deleted. This will enable a successful terraform destroy when destroying CloudSQL instances. Use with care as it can lead to dangling resources.
-        varType: string
-      - name: description
-        description: An optional description of the Global Address resource.
-        varType: string
-        defaultValue: ""
-      - name: ip_version
-        description: IP Version for the allocation. Can be IPV4 or IPV6.
-        varType: string
-        defaultValue: ""
-      - name: labels
-        description: The key/value labels for the IP range allocated to the peered network.
-        varType: map(string)
-        defaultValue: {}
-      - name: prefix_length
-        description: Prefix length of the IP range reserved for Cloud SQL instances and other Private Service Access services. Defaults to /16.
-        varType: number
-        defaultValue: 16
       - name: project_id
         description: The project ID of the VPC network to peer. This can be a shared VPC host projec.
         varType: string
@@ -93,6 +56,29 @@ spec:
         description: Name of the VPC network to peer.
         varType: string
         required: true
+      - name: address
+        description: First IP address of the IP range to allocate to CLoud SQL instances and other Private Service Access services. If not set, GCP will pick a valid one for you.
+        varType: string
+        defaultValue: ""
+      - name: description
+        description: An optional description of the Global Address resource.
+        varType: string
+        defaultValue: ""
+      - name: prefix_length
+        description: Prefix length of the IP range reserved for Cloud SQL instances and other Private Service Access services. Defaults to /16.
+        varType: number
+        defaultValue: 16
+      - name: ip_version
+        description: IP Version for the allocation. Can be IPV4 or IPV6.
+        varType: string
+        defaultValue: ""
+      - name: labels
+        description: The key/value labels for the IP range allocated to the peered network.
+        varType: map(string)
+        defaultValue: {}
+      - name: deletion_policy
+        description: The deletion policy for the service networking connection. Setting to ABANDON allows the resource to be abandoned rather than deleted. This will enable a successful terraform destroy when destroying CloudSQL instances. Use with care as it can lead to dangling resources.
+        varType: string
     outputs:
       - name: address
         description: First IP of the reserved range.
@@ -104,26 +90,15 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudkms.admin
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
-          - roles/cloudscheduler.admin
-          - roles/cloudsql.admin
-          - roles/compute.admin
-          - roles/compute.networkAdmin
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
-          - roles/monitoring.editor
-          - roles/resourcemanager.projectIamAdmin
-          - roles/storage.admin
-          - roles/workflows.admin
+          - roles/servicenetworking.networksAdmin
     services:
-      - cloudkms.googleapis.com
-      - cloudresourcemanager.googleapis.com
-      - cloudscheduler.googleapis.com
-      - compute.googleapis.com
-      - iam.googleapis.com
-      - monitoring.googleapis.com
       - servicenetworking.googleapis.com
       - serviceusage.googleapis.com
-      - sqladmin.googleapis.com
-      - workflows.googleapis.com
+    providerVersions:
+      - source: hashicorp/google
+        version: ">= 5.38, < 7"
+      - source: hashicorp/google-beta
+        version: ">= 5.38, < 7"
+      - source: hashicorp/null
+        version: ~> 3.1

--- a/modules/restore/metadata.yaml
+++ b/modules/restore/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/modules/restore/metadata.yaml
+++ b/modules/restore/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2025 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/modules/restore/metadata.yaml
+++ b/modules/restore/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -27,7 +13,7 @@ spec:
       dir: /modules/restore
     actuationTool:
       flavor: Terraform
-      version: ">= 0.13"
+      version: ">= 1.3"
     description: {}
   content:
     examples:
@@ -61,18 +47,6 @@ spec:
         location: examples/private_service_access
   interfaces:
     variables:
-      - name: import_databases
-        description: The list of databases that should be imported - if is an empty set all databases will be imported
-        varType: set(string)
-        defaultValue: []
-      - name: import_uri
-        description: The bucket and path uri of GCS backup file for importing
-        varType: string
-        required: true
-      - name: project_id
-        description: The project ID
-        varType: string
-        required: true
       - name: region
         description: The region to run the workflow
         varType: string
@@ -80,8 +54,20 @@ spec:
       - name: service_account
         description: The service account to use for running the workflow and triggering the workflow by Cloud Scheduler - If empty or null a service account will be created. If you have provided a service account you need to grant the Cloud SQL Admin and the Workflows Invoker role to that
         varType: string
+      - name: project_id
+        description: The project ID
+        varType: string
+        required: true
       - name: sql_instance
         description: The name of the SQL instance to backup
+        varType: string
+        required: true
+      - name: import_databases
+        description: The list of databases that should be imported - if is an empty set all databases will be imported
+        varType: set(string)
+        defaultValue: []
+      - name: import_uri
+        description: The bucket and path uri of GCS backup file for importing
         varType: string
         required: true
     outputs:
@@ -95,26 +81,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudkms.admin
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
-          - roles/cloudscheduler.admin
           - roles/cloudsql.admin
-          - roles/compute.admin
-          - roles/compute.networkAdmin
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
-          - roles/monitoring.editor
-          - roles/resourcemanager.projectIamAdmin
-          - roles/storage.admin
-          - roles/workflows.admin
+          - roles/logging.logWriter
     services:
-      - cloudkms.googleapis.com
-      - cloudresourcemanager.googleapis.com
-      - cloudscheduler.googleapis.com
-      - compute.googleapis.com
-      - iam.googleapis.com
-      - monitoring.googleapis.com
-      - servicenetworking.googleapis.com
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com
-      - workflows.googleapis.com
+    providerVersions:
+      - source: hashicorp/google
+        version: ">= 4.0, < 7"

--- a/modules/restore/metadata.yaml
+++ b/modules/restore/metadata.yaml
@@ -95,9 +95,9 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/logging.logWriter
           - roles/cloudsql.admin
           - roles/iam.serviceAccountUser
-          - roles/logging.logWriter
     services:
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com

--- a/modules/restore/metadata.yaml
+++ b/modules/restore/metadata.yaml
@@ -95,9 +95,9 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/logging.logWriter
           - roles/cloudsql.admin
           - roles/iam.serviceAccountUser
+          - roles/logging.logWriter
     services:
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com

--- a/modules/safer_mysql/metadata.yaml
+++ b/modules/safer_mysql/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/modules/safer_mysql/metadata.yaml
+++ b/modules/safer_mysql/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2025 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/modules/safer_mysql/metadata.yaml
+++ b/modules/safer_mysql/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -62,41 +48,134 @@ spec:
         location: examples/private_service_access
   interfaces:
     variables:
+      - name: project_id
+        description: The project ID to manage the Cloud SQL resources
+        varType: string
+        required: true
+      - name: name
+        description: The name of the Cloud SQL resources
+        varType: string
+        required: true
+      - name: random_instance_name
+        description: Sets random suffix at the end of the Cloud SQL resource name
+        varType: bool
+        defaultValue: false
+      - name: database_version
+        description: The database version to use
+        varType: string
+        required: true
+      - name: maintenance_version
+        description: The current software version on the instance. This attribute can not be set during creation. Refer to available_maintenance_versions attribute to see what maintenance_version are available for upgrade. When this attribute gets updated, it will cause an instance restart. Setting a maintenance_version value that is older than the current one on the instance will be ignored
+        varType: string
+      - name: region
+        description: The region of the Cloud SQL resources
+        varType: string
+        required: true
+      - name: vpc_network
+        description: Existing VPC network to which instances are connected. The networks needs to be configured with https://cloud.google.com/vpc/docs/configure-private-services-access.
+        varType: string
+        required: true
+      - name: allocated_ip_range
+        description: Existing allocated IP range name for the Private IP CloudSQL instance. The networks needs to be configured with https://cloud.google.com/vpc/docs/configure-private-services-access.
+        varType: string
+      - name: tier
+        description: The tier for the master instance.
+        varType: string
+        defaultValue: db-n1-standard-1
+      - name: edition
+        description: The edition of the instance, can be ENTERPRISE or ENTERPRISE_PLUS.
+        varType: string
+      - name: zone
+        description: "The zone for the master instance, it should be something like: `us-central1-a`, `us-east1-c`."
+        varType: string
+      - name: secondary_zone
+        description: "The preferred zone for the secondary/failover instance, it should be something like: `us-central1-a`, `us-east1-c`."
+        varType: string
+      - name: master_instance_name
+        description: The name of the existing instance that will act as the master in the replication setup.
+        varType: string
+      - name: failover_dr_replica_name
+        description: If the instance is a primary instance, then this field identifies the disaster recovery (DR) replica. The standard format of this field is "your-project:your-instance". You can also set this field to "your-instance", but cloud SQL backend will convert it to the aforementioned standard format.
+        varType: string
+      - name: instance_type
+        description: Users can upgrade a read replica instance to a stand-alone Cloud SQL instance with the help of instance_type. To promote, users have to set the instance_type property as CLOUD_SQL_INSTANCE and remove/unset master_instance_name and replica_configuration from instance configuration. This operation might cause your instance to restart.
+        varType: string
+      - name: follow_gae_application
+        description: A Google App Engine application whose zone to remain in. Must be in the same region as this instance.
+        varType: string
       - name: activation_policy
         description: The activation policy for the master instance. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`.
         varType: string
         defaultValue: ALWAYS
-      - name: additional_databases
-        description: A list of databases to be created in your cluster
-        varType: |-
-          list(object({
-              name      = string
-              charset   = string
-              collation = string
-            }))
-        defaultValue: []
-      - name: additional_users
-        description: A list of users to be created in your cluster. A random password would be set for the user if the `random_password` variable is set.
-        varType: |-
-          list(object({
-              name            = string
-              password        = string
-              host            = string
-              type            = string
-              random_password = bool
-            }))
-        defaultValue: []
-      - name: allocated_ip_range
-        description: Existing allocated IP range name for the Private IP CloudSQL instance. The networks needs to be configured with https://cloud.google.com/vpc/docs/configure-private-services-access.
-        varType: string
-      - name: assign_public_ip
-        description: Set to true if the master instance should also have a public IP (less secure).
-        varType: bool
-        defaultValue: false
       - name: availability_type
         description: The availability type for the master instance. Can be either `REGIONAL` or `null`.
         varType: string
         defaultValue: REGIONAL
+      - name: deletion_protection_enabled
+        description: Enables protection of an instance from accidental deletion across all surfaces (API, gcloud, Cloud Console and Terraform).
+        varType: bool
+        defaultValue: false
+      - name: read_replica_deletion_protection_enabled
+        description: Enables protection of a read replica from accidental deletion across all surfaces (API, gcloud, Cloud Console and Terraform).
+        varType: bool
+        defaultValue: false
+      - name: disk_autoresize
+        description: Configuration to increase storage size
+        varType: bool
+        defaultValue: true
+      - name: disk_autoresize_limit
+        description: The maximum size to which storage can be auto increased.
+        varType: number
+        defaultValue: 0
+      - name: disk_size
+        description: The disk size for the master instance
+        varType: number
+        defaultValue: 10
+      - name: disk_type
+        description: The disk type for the master instance.
+        varType: string
+        defaultValue: PD_SSD
+      - name: pricing_plan
+        description: The pricing plan for the master instance.
+        varType: string
+        defaultValue: PER_USE
+      - name: maintenance_window_day
+        description: The day of week (1-7) for the master instance maintenance.
+        varType: number
+        defaultValue: 1
+      - name: maintenance_window_hour
+        description: The hour of day (0-23) maintenance window for the master instance maintenance.
+        varType: number
+        defaultValue: 23
+      - name: maintenance_window_update_track
+        description: The update track of maintenance window for the master instance maintenance. Can be either `canary` or `stable`.
+        varType: string
+        defaultValue: stable
+      - name: data_cache_enabled
+        description: Whether data cache is enabled for the instance. Defaults to false. Feature is only available for ENTERPRISE_PLUS tier and supported database_versions
+        varType: bool
+        defaultValue: false
+      - name: deny_maintenance_period
+        description: The Deny Maintenance Period fields to prevent automatic maintenance from occurring during a 90-day time period. List accepts only one value. See [more details](https://cloud.google.com/sql/docs/mysql/maintenance)
+        varType: |-
+          list(object({
+              end_date   = string
+              start_date = string
+              time       = string
+            }))
+        defaultValue: []
+      - name: database_flags
+        description: The database flags for the master instance. See [more details](https://cloud.google.com/sql/docs/mysql/flags)
+        varType: |-
+          list(object({
+              name  = string
+              value = string
+            }))
+        defaultValue: []
+      - name: user_labels
+        description: The key/value labels for the master instances.
+        varType: map(string)
+        defaultValue: {}
       - name: backup_configuration
         description: The backup_configuration settings subblock for the database setings
         varType: |-
@@ -117,148 +196,12 @@ spec:
           retention_unit: null
           start_time: null
           transaction_log_retention_days: null
-      - name: create_timeout
-        description: The optional timout that is applied to limit long database creates.
-        varType: string
-        defaultValue: 30m
-      - name: data_cache_enabled
-        description: Whether data cache is enabled for the instance. Defaults to false. Feature is only available for ENTERPRISE_PLUS tier and supported database_versions
-        varType: bool
-        defaultValue: false
-      - name: database_flags
-        description: The database flags for the master instance. See [more details](https://cloud.google.com/sql/docs/mysql/flags)
-        varType: |-
-          list(object({
-              name  = string
-              value = string
-            }))
-        defaultValue: []
-      - name: database_version
-        description: The database version to use
-        varType: string
-        required: true
-      - name: db_charset
-        description: The charset for the default database
-        varType: string
-        defaultValue: ""
-      - name: db_collation
-        description: "The collation for the default database. Example: 'utf8_general_ci'"
-        varType: string
-        defaultValue: ""
-      - name: db_name
-        description: The name of the default database to create
-        varType: string
-        defaultValue: default
-      - name: delete_timeout
-        description: The optional timout that is applied to limit long database deletes.
-        varType: string
-        defaultValue: 30m
-      - name: deletion_protection
-        description: Used to block Terraform from deleting a SQL Instance.
+      - name: retain_backups_on_delete
+        description: When this parameter is set to true, Cloud SQL retains backups of the instance even after the instance is deleted. The ON_DEMAND backup will be retained until customer deletes the backup or the project. The AUTOMATED backup will be retained based on the backups retention setting.
         varType: bool
         defaultValue: true
-      - name: deletion_protection_enabled
-        description: Enables protection of an instance from accidental deletion across all surfaces (API, gcloud, Cloud Console and Terraform).
-        varType: bool
-        defaultValue: false
-      - name: deny_maintenance_period
-        description: The Deny Maintenance Period fields to prevent automatic maintenance from occurring during a 90-day time period. List accepts only one value. See [more details](https://cloud.google.com/sql/docs/mysql/maintenance)
-        varType: |-
-          list(object({
-              end_date   = string
-              start_date = string
-              time       = string
-            }))
-        defaultValue: []
-      - name: disk_autoresize
-        description: Configuration to increase storage size
-        varType: bool
-        defaultValue: true
-      - name: disk_autoresize_limit
-        description: The maximum size to which storage can be auto increased.
-        varType: number
-        defaultValue: 0
-      - name: disk_size
-        description: The disk size for the master instance
-        varType: number
-        defaultValue: 10
-      - name: disk_type
-        description: The disk type for the master instance.
-        varType: string
-        defaultValue: PD_SSD
-      - name: edition
-        description: The edition of the instance, can be ENTERPRISE or ENTERPRISE_PLUS.
-        varType: string
-      - name: encryption_key_name
-        description: The full path to the encryption key used for the CMEK disk encryption
-        varType: string
-      - name: failover_dr_replica_name
-        description: If the instance is a primary instance, then this field identifies the disaster recovery (DR) replica. The standard format of this field is "your-project:your-instance". You can also set this field to "your-instance", but cloud SQL backend will convert it to the aforementioned standard format.
-        varType: string
-      - name: follow_gae_application
-        description: A Google App Engine application whose zone to remain in. Must be in the same region as this instance.
-        varType: string
-      - name: iam_users
-        description: A list of IAM users to be created in your CloudSQL instance
-        varType: |-
-          list(object({
-              id    = string,
-              email = string
-            }))
-        defaultValue: []
-      - name: insights_config
-        description: The insights_config settings for the database.
-        varType: |-
-          object({
-              query_plans_per_minute  = number
-              query_string_length     = number
-              record_application_tags = bool
-              record_client_address   = bool
-            })
-      - name: instance_type
-        description: Users can upgrade a read replica instance to a stand-alone Cloud SQL instance with the help of instance_type. To promote, users have to set the instance_type property as CLOUD_SQL_INSTANCE and remove/unset master_instance_name and replica_configuration from instance configuration. This operation might cause your instance to restart.
-        varType: string
-      - name: maintenance_window_day
-        description: The day of week (1-7) for the master instance maintenance.
-        varType: number
-        defaultValue: 1
-      - name: maintenance_window_hour
-        description: The hour of day (0-23) maintenance window for the master instance maintenance.
-        varType: number
-        defaultValue: 23
-      - name: maintenance_window_update_track
-        description: The update track of maintenance window for the master instance maintenance. Can be either `canary` or `stable`.
-        varType: string
-        defaultValue: stable
-      - name: master_instance_name
-        description: The name of the existing instance that will act as the master in the replication setup.
-        varType: string
-      - name: module_depends_on
-        description: List of modules or resources this module depends on.
-        varType: list(any)
-        defaultValue: []
-      - name: name
-        description: The name of the Cloud SQL resources
-        varType: string
-        required: true
-      - name: pricing_plan
-        description: The pricing plan for the master instance.
-        varType: string
-        defaultValue: PER_USE
-      - name: project_id
-        description: The project ID to manage the Cloud SQL resources
-        varType: string
-        required: true
-      - name: random_instance_name
-        description: Sets random suffix at the end of the Cloud SQL resource name
-        varType: bool
-        defaultValue: false
-      - name: read_replica_deletion_protection
-        description: Used to block Terraform from deleting replica SQL Instances.
-        varType: bool
-        defaultValue: false
-      - name: read_replica_deletion_protection_enabled
-        description: Enables protection of a read replica from accidental deletion across all surfaces (API, gcloud, Cloud Console and Terraform).
+      - name: assign_public_ip
+        description: Set to true if the master instance should also have a public IP (less secure).
         varType: bool
         defaultValue: false
       - name: read_replica_name_suffix
@@ -294,31 +237,40 @@ spec:
                 authorized_networks = list(map(string))
                 ipv4_enabled        = bool
                 private_network     = string
-                require_ssl         = bool
                 allocated_ip_range  = string
               })
               encryption_key_name = string
             }))
         defaultValue: []
-      - name: region
-        description: The region of the Cloud SQL resources
+      - name: enable_default_db
+        description: Enable or disable the creation of the default database
+        varType: bool
+        defaultValue: true
+      - name: db_name
+        description: The name of the default database to create
         varType: string
-        required: true
-      - name: secondary_zone
-        description: "The preferred zone for the secondary/failover instance, it should be something like: `us-central1-a`, `us-east1-c`."
+        defaultValue: default
+      - name: db_charset
+        description: The charset for the default database
         varType: string
-      - name: tier
-        description: The tier for the master instance.
+        defaultValue: ""
+      - name: db_collation
+        description: "The collation for the default database. Example: 'utf8_general_ci'"
         varType: string
-        defaultValue: db-n1-standard-1
-      - name: update_timeout
-        description: The optional timout that is applied to limit long database updates.
-        varType: string
-        defaultValue: 30m
-      - name: user_labels
-        description: The key/value labels for the master instances.
-        varType: map(string)
-        defaultValue: {}
+        defaultValue: ""
+      - name: additional_databases
+        description: A list of databases to be created in your cluster
+        varType: |-
+          list(object({
+              name      = string
+              charset   = string
+              collation = string
+            }))
+        defaultValue: []
+      - name: enable_default_user
+        description: Enable or disable the creation of the default user
+        varType: bool
+        defaultValue: true
       - name: user_name
         description: The name of the default user
         varType: string
@@ -327,13 +279,62 @@ spec:
         description: The password for the default user. If not set, a random one will be generated and available in the generated_user_password output variable.
         varType: string
         defaultValue: ""
-      - name: vpc_network
-        description: Existing VPC network to which instances are connected. The networks needs to be configured with https://cloud.google.com/vpc/docs/configure-private-services-access.
+      - name: additional_users
+        description: A list of users to be created in your cluster. A random password would be set for the user if the `random_password` variable is set.
+        varType: |-
+          list(object({
+              name            = string
+              password        = string
+              host            = string
+              type            = string
+              random_password = bool
+            }))
+        defaultValue: []
+      - name: iam_users
+        description: A list of IAM users to be created in your CloudSQL instance. iam.users.type can be CLOUD_IAM_USER, CLOUD_IAM_SERVICE_ACCOUNT, CLOUD_IAM_GROUP and is required for type CLOUD_IAM_GROUP (IAM groups)
+        varType: |-
+          list(object({
+              id    = string,
+              email = string,
+              type  = optional(string)
+            }))
+        defaultValue: []
+      - name: create_timeout
+        description: The optional timout that is applied to limit long database creates.
         varType: string
-        required: true
-      - name: zone
-        description: "The zone for the master instance, it should be something like: `us-central1-a`, `us-east1-c`."
+        defaultValue: 30m
+      - name: update_timeout
+        description: The optional timout that is applied to limit long database updates.
         varType: string
+        defaultValue: 30m
+      - name: delete_timeout
+        description: The optional timout that is applied to limit long database deletes.
+        varType: string
+        defaultValue: 30m
+      - name: module_depends_on
+        description: List of modules or resources this module depends on.
+        varType: list(any)
+        defaultValue: []
+      - name: deletion_protection
+        description: Used to block Terraform from deleting a SQL Instance.
+        varType: bool
+        defaultValue: true
+      - name: read_replica_deletion_protection
+        description: Used to block Terraform from deleting replica SQL Instances.
+        varType: bool
+        defaultValue: false
+      - name: encryption_key_name
+        description: The full path to the encryption key used for the CMEK disk encryption
+        varType: string
+      - name: insights_config
+        description: The insights_config settings for the database.
+        varType: |-
+          object({
+              query_plans_per_minute  = number
+              query_string_length     = number
+              record_application_tags = bool
+              record_client_address   = bool
+            })
     outputs:
       - name: generated_user_password
         description: The auto generated default user password if not input password was provided
@@ -369,26 +370,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudkms.admin
-          - roles/cloudkms.cryptoKeyEncrypterDecrypter
-          - roles/cloudscheduler.admin
           - roles/cloudsql.admin
-          - roles/compute.admin
-          - roles/compute.networkAdmin
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
-          - roles/monitoring.editor
-          - roles/resourcemanager.projectIamAdmin
-          - roles/storage.admin
-          - roles/workflows.admin
+          - roles/logging.logWriter
     services:
-      - cloudkms.googleapis.com
-      - cloudresourcemanager.googleapis.com
-      - cloudscheduler.googleapis.com
-      - compute.googleapis.com
-      - iam.googleapis.com
-      - monitoring.googleapis.com
-      - servicenetworking.googleapis.com
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com
-      - workflows.googleapis.com
+    providerVersions:
+      - source: hashicorp/google
+        version: ">= 6.31, < 7"

--- a/modules/safer_mysql/metadata.yaml
+++ b/modules/safer_mysql/metadata.yaml
@@ -384,9 +384,9 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/cloudsql.admin
           - roles/iam.serviceAccountUser
           - roles/logging.logWriter
+          - roles/cloudsql.admin
     services:
       - serviceusage.googleapis.com
       - sqladmin.googleapis.com

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -15,21 +15,61 @@
  */
 
 locals {
-  int_required_roles = [
+  per_module_roles = {
+    backup = [
+      "roles/cloudsql.admin",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+    mssql = [
+      "roles/cloudsql.admin",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+    mysql = [
+      "roles/cloudsql.admin",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+    postgresql = [
+      "roles/cloudsql.admin",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+    private_service_access = [
+      "roles/servicenetworking.networksAdmin",
+      "roles/iam.serviceAccountUser",
+    ]
+    restore = [
+      "roles/cloudsql.admin",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+    safer_mysql = [
+      "roles/cloudsql.admin",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+    root = [
+      "roles/resourcemanager.projectIamAdmin",
+      "roles/serviceusage.serviceUsageAdmin",
+      "roles/cloudsql.admin",
+      "roles/iam.serviceAccountAdmin",
+      "roles/iam.serviceAccountUser",
+    ]
+  }
+
+  int_required_roles = concat([
     "roles/cloudkms.admin",
     "roles/cloudkms.autokeyAdmin",
     "roles/cloudkms.cryptoKeyEncrypterDecrypter",
     "roles/cloudscheduler.admin",
-    "roles/cloudsql.admin",
     "roles/compute.admin",
     "roles/compute.networkAdmin",
-    "roles/iam.serviceAccountAdmin",
-    "roles/iam.serviceAccountUser",
     "roles/monitoring.editor",
-    "roles/resourcemanager.projectIamAdmin",
     "roles/storage.admin",
     "roles/workflows.admin",
-  ]
+  ], flatten(values(local.per_module_roles)))
 }
 
 resource "google_service_account" "int_test" {

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -36,10 +36,13 @@ locals {
     ]
     postgresql = [
       "roles/cloudsql.admin",
+      "roles/storage.admin",
       "roles/resourcemanager.projectIamAdmin",
       "roles/iam.serviceAccountUser",
       "roles/compute.networkAdmin",
       "roles/cloudkms.admin",
+      "roles/cloudkms.autokeyAdmin",
+      "roles/cloudkms.cryptoKeyEncrypterDecrypter",
       "roles/logging.logWriter",
     ]
     private_service_access = [

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -28,12 +28,18 @@ locals {
     ]
     mysql = [
       "roles/cloudsql.admin",
+      "roles/resourcemanager.projectIamAdmin",
       "roles/iam.serviceAccountUser",
+      "roles/compute.networkAdmin",
+      "roles/cloudkms.cryptoKeyEncrypterDecrypter",
       "roles/logging.logWriter",
     ]
     postgresql = [
       "roles/cloudsql.admin",
+      "roles/resourcemanager.projectIamAdmin",
       "roles/iam.serviceAccountUser",
+      "roles/compute.networkAdmin",
+      "roles/cloudkms.admin",
       "roles/logging.logWriter",
     ]
     private_service_access = [

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -14,6 +14,45 @@
  * limitations under the License.
  */
 
+locals {
+  per_module_services = {
+    backup = [
+      "sqladmin.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+    mssql = [
+      "sqladmin.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+    mysql = [
+      "sqladmin.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+    postgresql = [
+      "sqladmin.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+    private_service_access = [
+      "servicenetworking.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+    restore = [
+      "sqladmin.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+    safer_mysql = [
+      "sqladmin.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+    root = [
+      "sqladmin.googleapis.com",
+      "serviceusage.googleapis.com",
+      "iam.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+    ]
+  }
+}
+
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 18.0"
@@ -25,18 +64,13 @@ module "project" {
   billing_account   = var.billing_account
   deletion_policy   = "DELETE"
 
-  activate_apis = [
+  activate_apis = concat([
     "cloudkms.googleapis.com",
-    "cloudresourcemanager.googleapis.com",
     "cloudscheduler.googleapis.com",
     "compute.googleapis.com",
-    "iam.googleapis.com",
     "monitoring.googleapis.com",
-    "servicenetworking.googleapis.com",
-    "serviceusage.googleapis.com",
-    "sqladmin.googleapis.com",
     "workflows.googleapis.com",
-  ]
+  ], flatten(values(local.per_module_services)))
 }
 
 resource "google_service_account" "cloudsql_pg_sa" {

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -42,6 +42,7 @@ locals {
     postgresql = [
       "sqladmin.googleapis.com",
       "serviceusage.googleapis.com",
+      "servicenetworking.googleapis.com",
       "iam.googleapis.com",
       "cloudkms.googleapis.com",
       "cloudresourcemanager.googleapis.com",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -32,6 +32,11 @@ locals {
     mysql = [
       "sqladmin.googleapis.com",
       "serviceusage.googleapis.com",
+      "iam.googleapis.com",
+      "cloudkms.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "compute.googleapis.com",
+      "monitoring.googleapis.com",
     ]
     postgresql = [
       "sqladmin.googleapis.com",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -23,6 +23,11 @@ locals {
     mssql = [
       "sqladmin.googleapis.com",
       "serviceusage.googleapis.com",
+      "iam.googleapis.com",
+      "cloudkms.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "compute.googleapis.com",
+      "monitoring.googleapis.com",
     ]
     mysql = [
       "sqladmin.googleapis.com",
@@ -31,6 +36,11 @@ locals {
     postgresql = [
       "sqladmin.googleapis.com",
       "serviceusage.googleapis.com",
+      "iam.googleapis.com",
+      "cloudkms.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "compute.googleapis.com",
+      "monitoring.googleapis.com",
     ]
     private_service_access = [
       "servicenetworking.googleapis.com",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -32,6 +32,7 @@ locals {
     mysql = [
       "sqladmin.googleapis.com",
       "serviceusage.googleapis.com",
+      "servicenetworking.googleapis.com",
       "iam.googleapis.com",
       "cloudkms.googleapis.com",
       "cloudresourcemanager.googleapis.com",


### PR DESCRIPTION
Introduced:

- per_module_roles: to config required roles to run each sub modules.
- per_module_service: to config required services to run each sub modules.

Added feature flag `--per-module-requirements` to generate_docs cmd, to align with the per module configs.