### PR TITLE
fix: revert psc_config workaround - causes permanent drift

### DIFF
--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -63,10 +63,10 @@ resource "google_sql_database_instance" "replicas" {
           }
         }
         dynamic "psc_config" {
-          for_each = ip_configuration.value.psc_enabled ? ["psc_enabled"] : ["psc_disabled"]
+          for_each = ip_configuration.value.psc_enabled ? ["psc_enabled"] : []
           content {
             psc_enabled               = ip_configuration.value.psc_enabled
-            allowed_consumer_projects = ip_configuration.value.psc_enabled ? ip_configuration.value.psc_allowed_consumer_projects : []
+            allowed_consumer_projects = ip_configuration.value.psc_allowed_consumer_projects
           }
         }
       }


### PR DESCRIPTION
## Problem
PR #718 was a temporary [workaround](https://github.com/terraform-google-modules/terraform-google-sql-db/pull/718#issuecomment-2789662923) for a provider bug, but now causes **permanent drift**:

```hcl
# Every terraform plan shows this, even when PSC is disabled:
+ psc_config {
    + allowed_consumer_projects = []
    + psc_enabled               = false
  }
```

**Root cause:** Workaround forces `psc_config` creation via `["psc_disabled"]`, but GCP API omits the block when PSC is disabled → constant state mismatch.

## Solution
The original provider issue is fixed, reverting to the original behavior:

```diff
- for_each = ip_configuration.value.psc_enabled ? ["psc_enabled"] : ["psc_disabled"]
+ for_each = lookup(ip_configuration.value, "psc_enabled", false) ? [1] : []
```

## Testing Results
✅ `psc_enabled = false` → No drift, no unnecessary blocks
✅ `psc_enabled = true` → Proper block creation
✅ No PSC config → No drift, clean plans

**Before:** `terraform plan` always shows psc_config changes
**After:** `terraform plan` shows "No changes" when appropriate

Reverts: #718 | Resolves: #750

What do you guys think?

Thanks.