### PR TITLE
Output the Service Attachment links for Replicas

### DIFF
--- a/modules/postgresql/outputs.tf
+++ b/modules/postgresql/outputs.tf
@@ -88,6 +88,12 @@ output "replicas_instance_server_ca_certs" {
   sensitive   = true
 }
 
+output "replicas_instance_psc_attachments" {
+  value       = [for r in google_sql_database_instance.replicas : r.psc_service_attachment_link]
+  description = "The psc_service_attachment_links created for the replica instances"
+  sensitive   = true
+}
+
 output "replicas_instance_service_account_email_addresses" {
   value       = [for r in google_sql_database_instance.replicas : r.service_account_email_address]
   description = "The service account email addresses assigned to the replica instances"


### PR DESCRIPTION
# Add service attachment outputs for Postgres replicas

Google's Terraform module for Postgres does not currently expose service attachment outputs for replicas,.This PR adds outputs for the service attachments of Postgres replicas in the Google Cloud SQL Terraform module.
The module already exposes the service attachment for the primary instance, but not for any replicas. This fills that gap so we can reference replica attachments just like the primary.