### PR TITLE
fix: add flag to prevent drift when enabling enhanced backups using the google_backup_dr_backup_plan_association resource

### DIFF
--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -33,8 +33,8 @@ locals {
   }
 
   // HA method using REGIONAL availability_type requires binary logs to be enabled
-  binary_log_enabled = var.availability_type == "REGIONAL" ? true : lookup(var.backup_configuration, "binary_log_enabled", null)
-  backups_enabled    = var.availability_type == "REGIONAL" ? true : lookup(var.backup_configuration, "enabled", null)
+  binary_log_enabled = var.availability_type == "REGIONAL" && var.enhanced_backup_enabled == false ? true : lookup(var.backup_configuration, "binary_log_enabled", null)
+  backups_enabled    = var.availability_type == "REGIONAL" && var.enhanced_backup_enabled == false ? true : lookup(var.backup_configuration, "enabled", null)
 
   retained_backups = lookup(var.backup_configuration, "retained_backups", null)
   retention_unit   = lookup(var.backup_configuration, "retention_unit", null)

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -518,3 +518,9 @@ variable "connection_pool_config" {
   })
   default = null
 }
+
+variable "enhanced_backup_enabled" {
+  description = "Used to override values for backup_configuration.binary_logs_enabled and backup_configuration.enabled if enhanced backups are enabled to prevent false config drift"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
It appears that when the `google_backup_dr_backup_plan_association` resource is used to link the backup plan to the cloud sql instance it makes some cloud sql changes out-of-band (not visible in the terraform plan). 

The following changes are made to the attributes of the backup_configuration object on the cloud sql instance

```
    enabled                        = false
    location                       = null
    binary_log_enabled             = false
    retained_backups               = null
    retention_unit                 = null
    start_time                     = null
    transaction_log_retention_days = 0
```

These changes are causing a “false” terraform diff as they are different to what is defined when calling the `GoogleCloudPlatform` `mysql` module.

The `GoogleCloudPlatform` `mysql` module has logic within it that will change the value for `backup_configuration.enabled` and `backup_configuration.binary_log_enabled` to `true` if the `availability_type == REGIONAL`. These both need to be false in order to match the changes in GCP after it is linked to the backup plan.

A `enhanced_backup_enabled` variable has been added to allow it to use the values provided rather than defaulting to `true` if the `availability_type == REGIONAL`.