### PR TITLE
Fix incorrect iterator references in connection_pool_config.flags

### DIFF
--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -188,12 +188,12 @@ resource "google_sql_database_instance" "default" {
     dynamic "connection_pool_config" {
       for_each = var.connection_pool_config != null ? [var.connection_pool_config] : []
       content {
-        connection_pooling_enabled = var.connection_pool_config.enabled
+        connection_pooling_enabled = connection_pool_config.enabled
         dynamic "flags" {
-          for_each = var.connection_pool_config.flags
+          for_each = try(connection_pool_config.value.flags, [])
           content {
-            name  = flags.name
-            value = flags.value
+            name  = flags.value.name
+            value = flags.value.value
           }
         }
       }


### PR DESCRIPTION
The nested dynamic block was using `flags.name / flags.value`, 
but in Terraform dynamic blocks the current iterated element must be accessed through the iterator’s .value. 
This change updates the block to use `flags.value.name `and `flags.value.value`, fixing the unsupported attribute error in main.tf.