### PR TITLE
feat(mysql,postgresql): add per-user password_policy support

### DIFF
--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -111,6 +111,7 @@ module "mysql-db" {
 | user\_labels | The key/value labels for the master instances. | `map(string)` | `{}` | no |
 | user\_name | The name of the default user | `string` | `"default"` | no |
 | user\_password | The password for the default user. If not set, a random one will be generated and available in the generated\_user\_password output variable. | `string` | `""` | no |
+| user\_password\_policy | The per-user password policy for built-in database users. Applies to the default user and all additional\_users. See https://cloud.google.com/sql/docs/mysql/built-in-authentication#password_policy | <pre>object({<br>    allowed_failed_attempts      = optional(number)<br>    enable_failed_attempts_check = optional(bool)<br>    enable_password_verification = optional(bool)<br>    password_expiration_duration = optional(string)<br>  })</pre> | `null` | no |
 | zone | The zone for the master instance, it should be something like: `us-central1-a`, `us-east1-c`. | `string` | `null` | no |
 
 ## Outputs

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -312,6 +312,17 @@ resource "google_sql_user" "default" {
   instance = google_sql_database_instance.default.name
   host     = var.user_host
   password = var.user_password == "" ? random_password.user-password[0].result : var.user_password
+
+  dynamic "password_policy" {
+    for_each = var.user_password_policy != null ? [var.user_password_policy] : []
+    content {
+      allowed_failed_attempts      = password_policy.value.allowed_failed_attempts
+      enable_failed_attempts_check = password_policy.value.enable_failed_attempts_check
+      enable_password_verification = password_policy.value.enable_password_verification
+      password_expiration_duration = password_policy.value.password_expiration_duration
+    }
+  }
+
   depends_on = [
     null_resource.module_depends_on,
     google_sql_database_instance.default,
@@ -327,6 +338,17 @@ resource "google_sql_user" "additional_users" {
   host     = each.value.host == null ? var.user_host : each.value.host
   instance = google_sql_database_instance.default.name
   type     = coalesce(each.value.type, "BUILT_IN")
+
+  dynamic "password_policy" {
+    for_each = var.user_password_policy != null ? [var.user_password_policy] : []
+    content {
+      allowed_failed_attempts      = password_policy.value.allowed_failed_attempts
+      enable_failed_attempts_check = password_policy.value.enable_failed_attempts_check
+      enable_password_verification = password_policy.value.enable_password_verification
+      password_expiration_duration = password_policy.value.password_expiration_duration
+    }
+  }
+
   depends_on = [
     null_resource.module_depends_on,
     google_sql_database_instance.default,

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -379,6 +379,17 @@ variable "password_validation_policy_config" {
   default = null
 }
 
+variable "user_password_policy" {
+  description = "The per-user password policy for built-in database users. Applies to the default user and all additional_users. See https://cloud.google.com/sql/docs/mysql/built-in-authentication#password_policy"
+  type = object({
+    allowed_failed_attempts      = optional(number)
+    enable_failed_attempts_check = optional(bool)
+    enable_password_verification = optional(bool)
+    password_expiration_duration = optional(string)
+  })
+  default = null
+}
+
 // Read Replicas
 variable "read_replicas" {
   description = "List of read replicas to create. Encryption key is required for replica in different region. For replica in same region as master set encryption_key_name = null"

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -183,6 +183,7 @@ module "pg" {
 | user\_labels | The key/value labels for the Cloud SQL instances. | `map(string)` | `{}` | no |
 | user\_name | The name of the default user | `string` | `"default"` | no |
 | user\_password | The password for the default user. If not set, a random one will be generated and available in the generated\_user\_password output variable. | `string` | `""` | no |
+| user\_password\_policy | The per-user password policy for built-in database users. Applies to the default user and all additional\_users. See https://cloud.google.com/sql/docs/postgres/built-in-authentication#password_policy | <pre>object({<br>    allowed_failed_attempts      = optional(number)<br>    enable_failed_attempts_check = optional(bool)<br>    enable_password_verification = optional(bool)<br>    password_expiration_duration = optional(string)<br>  })</pre> | `null` | no |
 | zone | The zone for the Cloud SQL instance, it should be something like: `us-central1-a`, `us-east1-c`. | `string` | `null` | no |
 
 ## Outputs

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -335,6 +335,17 @@ resource "google_sql_user" "default" {
   project  = var.project_id
   instance = google_sql_database_instance.default.name
   password = var.user_password == "" ? random_password.user-password[0].result : var.user_password
+
+  dynamic "password_policy" {
+    for_each = var.user_password_policy != null ? [var.user_password_policy] : []
+    content {
+      allowed_failed_attempts      = password_policy.value.allowed_failed_attempts
+      enable_failed_attempts_check = password_policy.value.enable_failed_attempts_check
+      enable_password_verification = password_policy.value.enable_password_verification
+      password_expiration_duration = password_policy.value.password_expiration_duration
+    }
+  }
+
   depends_on = [
     null_resource.module_depends_on,
     google_sql_database_instance.default,
@@ -349,6 +360,17 @@ resource "google_sql_user" "additional_users" {
   name     = each.value.name
   password = each.value.random_password ? random_password.additional_passwords[each.value.name].result : each.value.password
   instance = google_sql_database_instance.default.name
+
+  dynamic "password_policy" {
+    for_each = var.user_password_policy != null ? [var.user_password_policy] : []
+    content {
+      allowed_failed_attempts      = password_policy.value.allowed_failed_attempts
+      enable_failed_attempts_check = password_policy.value.enable_failed_attempts_check
+      enable_password_verification = password_policy.value.enable_password_verification
+      password_expiration_duration = password_policy.value.password_expiration_duration
+    }
+  }
+
   depends_on = [
     null_resource.module_depends_on,
     google_sql_database_instance.default,

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -329,6 +329,17 @@ variable "password_validation_policy_config" {
   default = null
 }
 
+variable "user_password_policy" {
+  description = "The per-user password policy for built-in database users. Applies to the default user and all additional_users. See https://cloud.google.com/sql/docs/postgres/built-in-authentication#password_policy"
+  type = object({
+    allowed_failed_attempts      = optional(number)
+    enable_failed_attempts_check = optional(bool)
+    enable_password_verification = optional(bool)
+    password_expiration_duration = optional(string)
+  })
+  default = null
+}
+
 variable "ip_configuration" {
   description = "The ip configuration for the Cloud SQL instances."
   type = object({

--- a/modules/safer_mysql/README.md
+++ b/modules/safer_mysql/README.md
@@ -294,6 +294,7 @@ module "safer-mysql-db" {
 | user\_labels | The key/value labels for the master instances. | `map(string)` | `{}` | no |
 | user\_name | The name of the default user | `string` | `"default"` | no |
 | user\_password | The password for the default user. If not set, a random one will be generated and available in the generated\_user\_password output variable. | `string` | `""` | no |
+| user\_password\_policy | The per-user password policy for built-in database users. Applies to the default user and all additional\_users. See https://cloud.google.com/sql/docs/mysql/built-in-authentication#password_policy | <pre>object({<br>    allowed_failed_attempts      = optional(number)<br>    enable_failed_attempts_check = optional(bool)<br>    enable_password_verification = optional(bool)<br>    password_expiration_duration = optional(string)<br>  })</pre> | `null` | no |
 | vpc\_network | Existing VPC network to which instances are connected. The networks needs to be configured with https://cloud.google.com/vpc/docs/configure-private-services-access. | `string` | n/a | yes |
 | zone | The zone for the master instance, it should be something like: `us-central1-a`, `us-east1-c`. | `string` | `null` | no |
 

--- a/modules/safer_mysql/main.tf
+++ b/modules/safer_mysql/main.tf
@@ -85,6 +85,8 @@ module "safer_mysql" {
   additional_users = var.additional_users
   iam_users        = var.iam_users
 
+  user_password_policy = var.user_password_policy
+
   // Read replica
   read_replica_name_suffix                 = var.read_replica_name_suffix
   read_replica_deletion_protection         = var.read_replica_deletion_protection

--- a/modules/safer_mysql/variables.tf
+++ b/modules/safer_mysql/variables.tf
@@ -372,6 +372,17 @@ variable "iam_users" {
   default = []
 }
 
+variable "user_password_policy" {
+  description = "The per-user password policy for built-in database users. Applies to the default user and all additional_users. See https://cloud.google.com/sql/docs/mysql/built-in-authentication#password_policy"
+  type = object({
+    allowed_failed_attempts      = optional(number)
+    enable_failed_attempts_check = optional(bool)
+    enable_password_verification = optional(bool)
+    password_expiration_duration = optional(string)
+  })
+  default = null
+}
+
 variable "create_timeout" {
   description = "The optional timout that is applied to limit long database creates."
   type        = string


### PR DESCRIPTION
Adds support for configuring per-user password_policy blocks on google_sql_user resources in the mysql, postgresql, and safer_mysql modules.

This is distinct from the existing instance-level password_validation_policy (which controls password complexity rules like minimum length and character requirements). The per-user password_policy controls:

allowed_failed_attempts – Number of failed login attempts before the user is locked
enable_failed_attempts_check – Whether to track failed login attempts
enable_password_verification – Whether the user must provide their current password when changing it
password_expiration_duration – How long a password is valid before it must be changed