### PR TITLE
feat: Add postgresql & mysql connections with vpc

### DIFF
--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -313,6 +313,12 @@ spec:
             spec:
               outputExpr: network_id
               inputPath: private_network
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-network
+              version: ">= 16.0.1"
+            spec:
+              outputExpr: network_self_link
+              inputPath: private_network
       - name: password_validation_policy_config
         description: The password validation policy settings for the database instance.
         varType: |-

--- a/modules/postgresql/metadata.yaml
+++ b/modules/postgresql/metadata.yaml
@@ -291,6 +291,12 @@ spec:
             spec:
               outputExpr: network_id
               inputPath: private_network
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-network
+              version: ">= 16.0.1"
+            spec:
+              outputExpr: network_self_link
+              inputPath: private_network
       - name: read_replicas
         description: List of read replicas to create. Encryption key is required for replica in different region. For replica in same region as master set encryption_key_name = null
         varType: |-


### PR DESCRIPTION
This connection enables the creation of private instances of mysql & postgresql within VPC.

Testing details: 
connection params:
https://screenshot.googleplex.com/QxdkxXgxrivniwh
https://screenshot.googleplex.com/36EG4WRqdX7Meww

successful deployment:
https://screenshot.googleplex.com/6RFTT8oJeppLRNe