### PR TITLE
fix(mysql,postgresql): use password_wo instead of deprecated password attribute

### DIFF
--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -306,12 +306,13 @@ resource "random_password" "additional_passwords" {
 }
 
 resource "google_sql_user" "default" {
-  count    = var.enable_default_user ? 1 : 0
-  name     = var.user_name
-  project  = var.project_id
-  instance = google_sql_database_instance.default.name
-  host     = var.user_host
-  password = var.user_password == "" ? random_password.user-password[0].result : var.user_password
+  count               = var.enable_default_user ? 1 : 0
+  name                = var.user_name
+  project             = var.project_id
+  instance            = google_sql_database_instance.default.name
+  host                = var.user_host
+  password_wo         = var.user_password == "" ? random_password.user-password[0].result : var.user_password
+  password_wo_version = var.user_password_wo_version
   depends_on = [
     null_resource.module_depends_on,
     google_sql_database_instance.default,
@@ -320,13 +321,14 @@ resource "google_sql_user" "default" {
 }
 
 resource "google_sql_user" "additional_users" {
-  for_each = local.users
-  project  = var.project_id
-  name     = each.value.name
-  password = each.value.random_password ? random_password.additional_passwords[each.value.name].result : each.value.password
-  host     = each.value.host == null ? var.user_host : each.value.host
-  instance = google_sql_database_instance.default.name
-  type     = coalesce(each.value.type, "BUILT_IN")
+  for_each            = local.users
+  project             = var.project_id
+  name                = each.value.name
+  password_wo         = each.value.random_password ? random_password.additional_passwords[each.value.name].result : each.value.password
+  password_wo_version = each.value.password_wo_version
+  host                = each.value.host == null ? var.user_host : each.value.host
+  instance            = google_sql_database_instance.default.name
+  type                = coalesce(each.value.type, "BUILT_IN")
   depends_on = [
     null_resource.module_depends_on,
     google_sql_database_instance.default,

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -85,6 +85,12 @@ variable "user_password" {
   default     = ""
 }
 
+variable "user_password_wo_version" {
+  description = "Version number for the default user's write-only password. Increment this to trigger a password update."
+  type        = number
+  default     = 1
+}
+
 variable "user_host" {
   description = "The host for the default user"
   type        = string
@@ -128,11 +134,12 @@ variable "additional_databases" {
 variable "additional_users" {
   description = "A list of users to be created in your cluster. A random password would be set for the user if the `random_password` variable is set."
   type = list(object({
-    name            = string
-    password        = string
-    random_password = bool
-    type            = string
-    host            = string
+    name                = string
+    password            = string
+    random_password     = bool
+    type                = string
+    host                = string
+    password_wo_version = optional(number, 1)
   }))
   default = []
   validation {

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -330,11 +330,12 @@ resource "random_password" "additional_passwords" {
 }
 
 resource "google_sql_user" "default" {
-  count    = var.enable_default_user ? 1 : 0
-  name     = var.user_name
-  project  = var.project_id
-  instance = google_sql_database_instance.default.name
-  password = var.user_password == "" ? random_password.user-password[0].result : var.user_password
+  count               = var.enable_default_user ? 1 : 0
+  name                = var.user_name
+  project             = var.project_id
+  instance            = google_sql_database_instance.default.name
+  password_wo         = var.user_password == "" ? random_password.user-password[0].result : var.user_password
+  password_wo_version = var.user_password_wo_version
   depends_on = [
     null_resource.module_depends_on,
     google_sql_database_instance.default,
@@ -344,11 +345,12 @@ resource "google_sql_user" "default" {
 }
 
 resource "google_sql_user" "additional_users" {
-  for_each = local.users
-  project  = var.project_id
-  name     = each.value.name
-  password = each.value.random_password ? random_password.additional_passwords[each.value.name].result : each.value.password
-  instance = google_sql_database_instance.default.name
+  for_each            = local.users
+  project             = var.project_id
+  name                = each.value.name
+  password_wo         = each.value.random_password ? random_password.additional_passwords[each.value.name].result : each.value.password
+  password_wo_version = each.value.password_wo_version
+  instance            = google_sql_database_instance.default.name
   depends_on = [
     null_resource.module_depends_on,
     google_sql_database_instance.default,

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -89,6 +89,12 @@ variable "user_password" {
   default     = ""
 }
 
+variable "user_password_wo_version" {
+  description = "Version number for the default user's write-only password. Increment this to trigger a password update."
+  type        = number
+  default     = 1
+}
+
 variable "root_password" {
   description = "Initial root password during creation"
   type        = string
@@ -131,9 +137,10 @@ variable "data_cache_enabled" {
 variable "additional_users" {
   description = "A list of users to be created in your cluster. A random password would be set for the user if the `random_password` variable is set."
   type = list(object({
-    name            = string
-    password        = string
-    random_password = bool
+    name                = string
+    password            = string
+    random_password     = bool
+    password_wo_version = optional(number, 1)
   }))
   default = []
   validation {


### PR DESCRIPTION
## Description

Fixes #715

The `google_sql_user` resource now provides a write-only `password_wo` attribute (available since Google provider v6.27.0). Using the deprecated `password` attribute causes Terraform to emit warnings:

```
Warning: Available Write-only Attribute Alternative
The attribute password has a write-only alternative password_wo available.
Use the write-only alternative of the attribute when possible.
```

More importantly, `password_wo` prevents the password from being stored in Terraform state, which is a security improvement.

## Changes

### modules/mysql and modules/postgresql
- Replace `password` with `password_wo` in `google_sql_user.default` and `google_sql_user.additional_users` resources
- Add `user_password_wo_version` variable (default: 1) for the default user - increment to trigger password updates
- Add `password_wo_version` field (optional, default: 1) to `additional_users` object type

## Migration Guide

This is a **breaking change** for existing deployments. Users upgrading to this version should:

1. Add `password_wo_version = 1` to their configuration (or rely on the default)
2. Run `terraform plan` - existing passwords will be re-applied using the write-only attribute
3. The password will no longer appear in state after the next apply

For users who need the old behavior, pin to the previous module version.