### PR TITLE
fix: Change 'required' field in connection_pool_config variable to 'default' in mysql and postgresql metadata yaml files

### DIFF
--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -444,7 +444,7 @@ spec:
                 value = string
               })), [])
             })
-        required: true
+        required: false
     outputs:
       - name: additional_users
         description: List of maps of additional users and passwords

--- a/modules/mysql/metadata.yaml
+++ b/modules/mysql/metadata.yaml
@@ -444,7 +444,7 @@ spec:
                 value = string
               })), [])
             })
-        required: false
+        defaultValue: null
     outputs:
       - name: additional_users
         description: List of maps of additional users and passwords

--- a/modules/postgresql/metadata.yaml
+++ b/modules/postgresql/metadata.yaml
@@ -453,7 +453,7 @@ spec:
                 value = string
               })), [])
             })
-        required: false
+        defaultValue: null
     outputs:
       - name: additional_user_passwords_map
         description: Map of auto generated passwords for the additional users

--- a/modules/postgresql/metadata.yaml
+++ b/modules/postgresql/metadata.yaml
@@ -453,7 +453,7 @@ spec:
                 value = string
               })), [])
             })
-        required: true
+        required: false
     outputs:
       - name: additional_user_passwords_map
         description: Map of auto generated passwords for the additional users


### PR DESCRIPTION
Change 'required' field in connection_pool_config variable to 'default' in mysql and postgresql metadata yaml files

Component ingestion and Preview completed successfully with latest changes:
mysql successful preview -> https://paste.googleplex.com/4984958000168960#l=2599
postgresql successful preview-> https://paste.googleplex.com/6608999018528768#l=2676

Successful metadata validation: https://paste.googleplex.com/5932095848448000
